### PR TITLE
Docker file for fdsn-ws

### DIFF
--- a/cmd/fdsn-ws/Dockerfile
+++ b/cmd/fdsn-ws/Dockerfile
@@ -1,0 +1,10 @@
+FROM alpine:3.5
+
+RUN apk add --no-cache libxslt
+
+ADD ./ /
+
+WORKDIR /
+USER nobody
+EXPOSE 8080
+CMD ["/fdsn-ws"]


### PR DESCRIPTION
The quake bit of the fdsn-ws needs xslt as a command.  Add back in
the custom Docker file.