### PR TITLE
Switched from listing/filtering S3 keys to using data holdings functions

### DIFF
--- a/cmd/fdsn-ws/data_holdings.go
+++ b/cmd/fdsn-ws/data_holdings.go
@@ -93,7 +93,7 @@ func holdingsHandler(r *http.Request, h http.Header, b *bytes.Buffer) *weft.Resu
 // network, station, channel, and location are matched using POSIX regular expressions.
 // https://www.postgresql.org/docs/9.3/static/functions-matching.html
 // start and end should be set for all queries.
-func holdingsSearch(network, station, channel, location string, start, end time.Time) (keys []string, err error) {
+func holdingsSearch(network, station, location, channel string, start, end time.Time) (keys []string, err error) {
 	var rows *sql.Rows
 
 	rows, err = db.Query(`WITH s AS (SELECT DISTINCT ON (network, station, channel, location) streamPK

--- a/cmd/fdsn-ws/data_holdings_test.go
+++ b/cmd/fdsn-ws/data_holdings_test.go
@@ -63,8 +63,8 @@ func TestDataHoldingsSearch(t *testing.T) {
 		Holding: holdings.Holding{
 			Network:    "NZ",
 			Station:    "ABAZ",
-			Channel:    "ACE",
 			Location:   "01",
+			Channel:    "ACE",
 			Start:      time.Date(2016, time.January, 2, 0, 0, 0, 0, time.UTC),
 			NumSamples: 500000,
 		},
@@ -78,7 +78,7 @@ func TestDataHoldingsSearch(t *testing.T) {
 	start := time.Date(2016, time.January, 1, 0, 0, 0, 0, time.UTC)
 	end := time.Date(2017, time.January, 1, 0, 0, 0, 0, time.UTC)
 
-	keys, err := holdingsSearch("NZ", "A.AZ", "A.", "01", start, end)
+	keys, err := holdingsSearch("NZ", "A.AZ", "01", "A.", start, end)
 	if err != nil {
 		t.Error(err)
 	}

--- a/cmd/fdsn-ws/env.list
+++ b/cmd/fdsn-ws/env.list
@@ -17,4 +17,4 @@ FDSN_STATION=service.geonet.org.nz
 # AWS_ACCESS_KEY_ID and AWS_SECRET_ACCESS_KEY (or other valid AWS credential method)
 # must be properly set to access this bucket.
 AWS_REGION=ap-southeast-2
-S3_BUCKET=fdsn-travis-test.geonet.org.nz
+S3_BUCKET=fdsn-data.geonet.org.nz

--- a/cmd/fdsn-ws/routes_test.go
+++ b/cmd/fdsn-ws/routes_test.go
@@ -2,7 +2,9 @@ package main
 
 import (
 	"bytes"
+	"fmt"
 	"github.com/GeoNet/collect/mseed"
+	"github.com/GeoNet/fdsn/internal/holdings"
 	wt "github.com/GeoNet/weft/wefttest"
 	"io/ioutil"
 	"net/http"
@@ -22,7 +24,7 @@ var routes = wt.Requests{
 
 	{ID: wt.L(), URL: "/holdings/NZ.ABAZ.01.ACE.D.2016.097", Method: "POST", Status: http.StatusMethodNotAllowed},
 	{ID: wt.L(), URL: "/holdings/NZ.ABAZ.01.ACE.D.2016.097", Method: "PUT", Status: http.StatusUnauthorized},
-	{ID: wt.L(), URL: "/holdings/NZ.ABAZ.01.ACE.D.2016.097", Method: "DELETE", Status: http.StatusMethodNotAllowed},
+	{ID: wt.L(), URL: "/holdings/NZ.ABAZ.01.ACE.D.2016.097", Method: "DELETE", Status: http.StatusUnauthorized},
 
 	// fdsn-ws-event
 	{ID: wt.L(), URL: "/fdsnws/event/1", Content: "text/html"},
@@ -35,12 +37,12 @@ var routes = wt.Requests{
 	// fdsn-ws-dataselect
 	{ID: wt.L(), URL: "/fdsnws/dataselect/1", Content: "text/html"},
 	{ID: wt.L(), URL: "/fdsnws/dataselect/1/version", Content: "text/plain"},
-	{ID: wt.L(), URL: "/fdsnws/dataselect/1/query?starttime=2017-01-09T00:00:00&endtime=2017-01-09T23:00:00&network=NZ&station=CHST&location=01&channel=LOG", Content: "application/vnd.fdsn.mseed"},
+	{ID: wt.L(), URL: "/fdsnws/dataselect/1/query?starttime=2016-01-09T00:00:00&endtime=2016-01-09T23:00:00&network=NZ&station=CHST&location=01&channel=LOG", Content: "application/vnd.fdsn.mseed"},
 	// abbreviated params
-	{ID: wt.L(), URL: "/fdsnws/dataselect/1/query?start=2017-01-09T00:00:00&end=2017-01-09T23:00:00&net=NZ&sta=CHST&loc=01&cha=LOG", Content: "application/vnd.fdsn.mseed"},
-	//{ID: wt.L(), URL: "/fdsnws/dataselect/1/query?start=2017-01-09T00:00:00&end=2017-01-09T23:00:00&net=NZ&sta=CHST,ALRZ&loc=01&cha=LOG", Content: "application/vnd.fdsn.mseed"},
+	{ID: wt.L(), URL: "/fdsnws/dataselect/1/query?start=2016-01-09T00:00:00&end=2016-01-09T23:00:00&net=NZ&sta=CHST&loc=01&cha=LOG", Content: "application/vnd.fdsn.mseed"},
+	//{ID: wt.L(), URL: "/fdsnws/dataselect/1/query?start=2016-01-09T00:00:00&end=2016-01-09T23:00:00&net=NZ&sta=CHST,ALRZ&loc=01&cha=LOG", Content: "application/vnd.fdsn.mseed"},
 	// an invalid network or no files matching query should give 404 (could also give 204 as per spec)
-	{ID: wt.L(), URL: "/fdsnws/dataselect/1/query?starttime=2017-01-09T00:00:00&endtime=2017-01-09T23:00:00&network=INVALID_NETWORK&station=CHST&location=01&channel=LOG",
+	{ID: wt.L(), URL: "/fdsnws/dataselect/1/query?starttime=2016-01-09T00:00:00&endtime=2016-01-09T23:00:00&network=INVALID_NETWORK&station=CHST&location=01&channel=LOG",
 		Content: "text/plain; charset=utf-8",
 		Status:  http.StatusNoContent},
 	// very old time range, no files:
@@ -56,6 +58,8 @@ var routes = wt.Requests{
 func TestRoutes(t *testing.T) {
 	setup(t)
 	defer teardown()
+
+	populateHoldings(t)
 
 	for _, r := range routes {
 		if b, err := r.Do(ts.URL); err != nil {
@@ -143,9 +147,11 @@ func TestPostSc3ml(t *testing.T) {
 
 // Test getting files from dataselect endpoint.  This is using an S3 bucket so the environment variables from env.list
 // must be valid and properly set
-func TestDataSelect(t *testing.T) {
+func TestDataSelectGet(t *testing.T) {
 	setup(t)
 	defer teardown()
+
+	populateHoldings(t)
 
 	// Testing GET first
 	u, err := url.Parse(ts.URL + "/fdsnws/dataselect/1/query")
@@ -153,19 +159,21 @@ func TestDataSelect(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	t1, err := time.Parse(time.RFC3339, "2017-01-01T00:00:00Z")
+	t1Str := "2016-01-01T22:00:00Z"
+	t1, err := time.Parse(time.RFC3339, t1Str)
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	t2, err := time.Parse(time.RFC3339, "2017-01-10T01:00:00Z")
+	t2Str := "2016-01-02T00:30:00Z"
+	t2, err := time.Parse(time.RFC3339, t2Str)
 	if err != nil {
 		t.Fatal(err)
 	}
 
 	values := url.Values{
-		"starttime": {"2017-01-09T00:00:00"},
-		"endtime":   {"2017-01-09T01:00:00"},
+		"starttime": {t1Str[0 : len(t1Str)-1]},
+		"endtime":   {t2Str[0 : len(t2Str)-1]},
 		"network":   {"NZ"},
 		"station":   {"ALRZ"},
 		"location":  {"10"},
@@ -180,18 +188,18 @@ func TestDataSelect(t *testing.T) {
 	}
 	defer resp.Body.Close()
 
+	var readBuff bytes.Buffer
+	if _, err = readBuff.ReadFrom(resp.Body); err != nil {
+		t.Fatal(err)
+	}
+
 	if resp.StatusCode != http.StatusOK {
-		t.Errorf("expected 200 got %d", resp.StatusCode)
+		t.Errorf("expected 200 got %d, body:%s", resp.StatusCode, string(readBuff.Bytes()))
 	}
 
 	// Read each record in the file, check times/net/sta/etc.
 	msr := mseed.NewMSRecord()
 	defer mseed.FreeMSRecord(msr)
-
-	var readBuff bytes.Buffer
-	if _, err = readBuff.ReadFrom(resp.Body); err != nil {
-		t.Fatal(err)
-	}
 
 	if readBuff.Len() == 0 {
 		t.Error("got empty response")
@@ -205,15 +213,15 @@ func TestDataSelect(t *testing.T) {
 		}
 
 		if err = msr.Unpack(record, RECORDLEN, 1, 0); err != nil {
-			t.Error(err)
+			t.Fatal(err)
 		}
 
 		if msr.Starttime().Before(t1) {
-			t.Error("start time of record was before specified starttime")
+			t.Fatal("start time of record was before specified starttime")
 		}
 
 		if msr.Starttime().After(t2) {
-			t.Error("end time of record was after specified endtime")
+			t.Fatal("end time of record was after specified endtime")
 		}
 
 		expectedHdrs := []string{values["network"][0], values["station"][0], values["location"][0], values["channel"][0]}
@@ -222,32 +230,40 @@ func TestDataSelect(t *testing.T) {
 			// These strings from C have a null terminator which breaks this comparison so trimming it
 			header = strings.TrimRight(header, "\x00")
 			if header != expectedHdrs[i] {
-				t.Errorf("expected header `%s` but observed: `%s`", header, expectedHdrs[i])
+				t.Fatalf("expected header `%s` but observed: `%s`", header, expectedHdrs[i])
 			}
 		}
 
 		// Just a couple quick sanity checks of the samples.  If msr.Unpack is getting this far we're probably ok.
-		if msr.Numsamples() < 200 || msr.Numsamples() > 500 {
-			t.Errorf("expected Numsamples between 200 and 500 but observed %d", msr.Numsamples())
+		if msr.Numsamples() < 200 || msr.Numsamples() > 700 {
+			t.Fatalf("expected Numsamples between 200 and 700 but observed %d", msr.Numsamples())
 		}
 
 		if msr.Samprate() != 100.0 {
-			t.Errorf("expected Samprate 100.0 but observed %f", msr.Samprate())
+			t.Fatalf("expected Samprate 100.0 but observed %f", msr.Samprate())
 		}
 	}
 
+}
+
+func TestDataSelectPost(t *testing.T) {
+	setup(t)
+	defer teardown()
+
+	populateHoldings(t)
 	// testing POST:
 	// The curl equivalent is: curl -v --data-binary @post_input.txt http://localhost:8080/fdsnws/dataselect/1/query -o test_post.mseed
 	var buf bytes.Buffer
 
+	// note: we ignore the parameters: quality/minimumlength/longestonly
 	postContent := []byte(`quality=M
 minimumlength=0.0
 longestonly=FALSE
-NZ ALRZ 10 EHN 2017-01-09T00:00:00 2017-01-09T02:00:00
-NZ ALRZ 10 EH* 2017-01-02T00:00:00 2017-01-02T01:00:00
-NZ ALRZ 01 V?? 2017-01-09T00:00:00 2017-01-10T00:00:00
-NZ ALRZ 01 VEP 2017-01-02T00:00:00 2017-01-10T00:00:00
-NZ ALRZ 01 VKI 2017-01-02T00:00:00.000000 2017-01-03T00:00:00.000000
+NZ ALRZ 10 EHN 2016-01-09T00:00:00 2016-01-09T02:00:00
+NZ ALRZ 10 EH* 2016-01-02T00:00:00 2016-01-02T01:00:00
+NZ ALRZ 01 V?? 2016-01-09T23:00:00 2016-01-10T00:00:00
+NZ ALRZ 01 VEP 2016-01-02T23:57:00 2016-01-03T00:00:00
+NZ ALRZ 01 VKI 2016-01-02T00:00:00.000000 2016-01-02T01:00:00.000000
 `)
 
 	buf.Write(postContent)
@@ -272,6 +288,20 @@ NZ ALRZ 01 VKI 2017-01-02T00:00:00.000000 2017-01-03T00:00:00.000000
 		t.Error("got empty response body")
 	}
 
+	tMin, err := time.Parse(time.RFC3339, "2016-01-02T00:00:00Z")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	tMax, err := time.Parse(time.RFC3339, "2016-01-10T00:00:00Z")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Read each record in the file, check times/net/sta/etc.
+	msr := mseed.NewMSRecord()
+	defer mseed.FreeMSRecord(msr)
+
 	// These records will be multiplexed with varying samplerates/lengths/etc.
 	for {
 		record := postReadBuff.Next(RECORDLEN)
@@ -281,20 +311,64 @@ NZ ALRZ 01 VKI 2017-01-02T00:00:00.000000 2017-01-03T00:00:00.000000
 		}
 
 		if err = msr.Unpack(record, RECORDLEN, 1, 0); err != nil {
-			t.Error(err)
+			t.Fatal(err)
 		}
 
-		if msr.Starttime().Before(t1) {
-			t.Error("start time of record was before specified starttime")
+		if msr.Starttime().Before(tMin) {
+			t.Fatal("start time of record was before tMin:", msr.Starttime(), tMin)
 		}
 
-		if msr.Starttime().After(t2) {
-			t.Error("end time of record was after specified endtime")
+		if msr.Starttime().After(tMax) {
+			t.Fatal("end time of record was after tMax:", msr.Starttime(), tMax)
 		}
 
 		// Just a couple quick sanity checks of the samples.  If msr.Unpack is getting this far we're probably ok.
 		if msr.Numsamples() < 87 || msr.Numsamples() > 700 {
-			t.Errorf("expected Numsamples between 87 and 700 but observed %d", msr.Numsamples())
+			t.Fatalf("expected Numsamples between 87 and 700 but observed %d", msr.Numsamples())
+		}
+	}
+}
+
+// populateDb inserts a thwack of holdings that exist in the bucket so we can run our integration tests against them
+func populateHoldings(t *testing.T) {
+	stations := []string{"ALRD", "ALRZ", "CHST"}
+	locations := []string{"01", "10"}
+	channels := []string{"EHN", "VEP", "VKI", "LOG"}
+
+	t1Str := "2016-01-01T00:00:00Z"
+	t1, err := time.Parse(time.RFC3339, t1Str)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	t2Str := "2016-01-10T00:00:00Z"
+	t2, err := time.Parse(time.RFC3339, t2Str)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	for _, sta := range stations {
+		for _, cha := range channels {
+			for _, loc := range locations {
+				for step := t1; step.Before(t2); step = step.Add(time.Hour * 24) {
+					h := holding{
+						key: fmt.Sprintf("%d/NZ/%s/%s.D/NZ.%s.%s.%s.D.%d.%03d", step.Year(), sta, cha, sta, loc, cha, step.Year(), step.YearDay()),
+						Holding: holdings.Holding{
+							Network:    "NZ",
+							Station:    sta,
+							Channel:    cha,
+							Location:   loc,
+							Start:      step,
+							NumSamples: 500000, // incorrect but we're just faking it
+						},
+					}
+
+					err = h.save()
+					if err != nil {
+						t.Fatal(err)
+					}
+				}
+			}
 		}
 	}
 }

--- a/cmd/fdsn-ws/s3data.go
+++ b/cmd/fdsn-ws/s3data.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"context"
-	"fmt"
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/client"
 	"github.com/aws/aws-sdk-go/aws/session"
@@ -10,9 +9,8 @@ import (
 	"github.com/aws/aws-sdk-go/service/s3/s3iface"
 	"io/ioutil"
 	"net/http"
-	"regexp"
-	"strconv"
 	"strings"
+	"time"
 )
 
 func newS3Client(p client.ConfigProvider, cfgs ...*aws.Config) s3iface.S3API {
@@ -80,155 +78,32 @@ func (s *s3DataSource) getObject(ctx context.Context, key string) (b []byte, err
 
 // matchingKeys returns a slice of strings (S3 keys - filenames) that match the search parameters.
 func (s *s3DataSource) matchingKeys(ctx context.Context) (keys []string, err error) {
-	prefix := s.prefix()
-	listParams := &s3.ListObjectsV2Input{
-		Bucket: &s.bucket,
-		Prefix: &prefix,
-	}
-
-	var resp *s3.ListObjectsV2Output
-	c := s.s3ClientFunc(s.session)
-	var contents []*s3.Object
-
-	// poorly documented: if resp.isTruncated is true we need to keep reading in chunks of 1000 until it is false
-	for {
-		if resp, err = c.ListObjectsV2WithContext(ctx, listParams); err != nil {
-			return nil, err
-		}
-
-		contents = append(contents, resp.Contents...)
-
-		// AWS using pointers to bools (?!) so need to check for nil
-		if resp.IsTruncated == nil || !*resp.IsTruncated {
-			break
-		}
-
-		listParams.ContinuationToken = resp.NextContinuationToken
-	}
-
-	var re *regexp.Regexp
-	if re, err = regexp.Compile(strings.Join(s.regexp(), `\.`)); err != nil {
-		return nil, err
-	}
-
-	for _, value := range contents {
-		if !re.MatchString(*value.Key) {
-			continue
-		}
-
-		// The regexp is weak at parsing the day of year so do it manually here
-		parts := strings.Split(*value.Key, ".")
-		var yearDayInt int
-		if yearDayInt, err = strconv.Atoi(parts[len(parts)-1]); err != nil {
-			return nil, err
-		}
-
-		if yearDayInt < s.params.StartTime.YearDay() || yearDayInt > s.params.EndTime.YearDay() {
-			continue
-		}
-
-		keys = append(keys, *value.Key)
-	}
-
-	return keys, nil
+	return holdingsSearch(s.regexp())
 }
 
-// prefix returns the prefix string to be used when querying all matching keys from an S3 bucket.  This cannot include
-// a full regexp search pattern since AWS does not support this.
-func (s *s3DataSource) prefix() (prefix string) {
-	var merged []string
-	for _, params := range s.searchPattern() {
-		merged = append(merged, commonSlice(params, "*"))
-	}
-
-	// s3 prefix does not support wildcards, so truncate if they're present
-	prefix = strings.Join(merged, ".")
-	prefix = strings.Split(prefix, "*")[0]
-	prefix = strings.Split(prefix, "?")[0]
-	// location can have two spaces or "--", neither of which exist in the S3 key name
-	prefix = strings.Split(prefix, " ")[0]
-	prefix = strings.Split(prefix, "--")[0]
-
-	return prefix
-}
-
-// regexp returns a regexp string to see if an S3 key matches the input parameters.  It converts
+// regexp returns a regexp string that represents the search parameters.  It converts
 // the '*', '?', ' ' and '--' characters to their regular expression equivalents for pattern matching with Go's regexp.
-func (s *s3DataSource) regexp() (pattern []string) {
+// It also handles multiple arguments, eg: two different networks.
+func (s *s3DataSource) regexp() (network, station, location, channel string, start, end time.Time) {
 
 	toPattern := func(params []string) (out string) {
 		var newParams []string
 		for _, param := range params {
-			newParam := strings.Replace(param, "*", `\w*`, -1)
-			newParam = strings.Replace(newParam, "?", `\w{1}`, -1)
+			newParam := strings.Replace(param, `*`, `\w*`, -1)
+			newParam = strings.Replace(newParam, `?`, `\w{1}`, -1)
 			// blank or missing locations, we convert spaces and two dashes to wildcards for the regexp
-			newParam = strings.Replace(newParam, "--", `\w{2}`, -1)
-			newParam = strings.Replace(newParam, " ", `\w{1}`, -1)
-			newParams = append(newParams, newParam)
+			newParam = strings.Replace(newParam, `--`, `\w{2}`, -1)
+			newParam = strings.Replace(newParam, ` `, `\w{1}`, -1)
+			newParams = append(newParams, `(^`+newParam+`$)`)
 		}
 
-		return "(" + strings.Join(newParams, "|") + ")"
+		return strings.Join(newParams, `|`)
 	}
 
-	fields := s.searchPattern()
-	for _, params := range fields {
-		pattern = append(pattern, toPattern(params))
-	}
-
-	return pattern
-}
-
-func (s *s3DataSource) searchPattern() [][]string {
-	startYear := fmt.Sprintf("%04d", s.params.StartTime.Year())
-	endYear := fmt.Sprintf("%04d", s.params.EndTime.Year())
-	year := commonString(startYear, endYear, "?")
-
-	startDoy := fmt.Sprintf("%03d", s.params.StartTime.YearDay())
-	endDoy := fmt.Sprintf("%03d", s.params.EndTime.YearDay())
-
-	// if we're looking at multiple years then parse every day of year
-	var doy string
-	if year == startYear && year == endYear {
-		doy = commonString(startDoy, endDoy, "?")
-	} else {
-		doy = "*"
-	}
-
-	return [][]string{s.params.Network, s.params.Station, s.params.Location, s.params.Channel, {"D"}, {year}, {doy}}
-}
-
-// commonSlice constructs a string from a slice of strings where any non-matching characters are replaced by the string wildCard
-func commonSlice(strs []string, wildcard string) (output string) {
-
-	if len(strs) == 0 {
-		return ""
-	}
-
-	if len(strs) == 1 {
-		return strs[0]
-	}
-
-	output = strs[0]
-	for _, s2 := range strs[1:] {
-		output = commonString(output, s2, wildcard)
-	}
-
-	return output
-}
-
-// commonString constructs a string from two input strings where any non-matching characters are replaced by the string wildCard
-func commonString(s1, s2, wildcard string) (output string) {
-	if s1 == s2 {
-		output = s1
-	} else {
-		for i, c := range s1 {
-			if c == rune(s2[i]) {
-				output += string(c)
-			} else {
-				output += wildcard
-			}
-		}
-	}
-
-	return output
+	return toPattern(s.params.Network),
+		toPattern(s.params.Station),
+		toPattern(s.params.Location),
+		toPattern(s.params.Channel),
+		s.params.StartTime.Time,
+		s.params.EndTime.Time
 }

--- a/cmd/fdsn-ws/s3data_test.go
+++ b/cmd/fdsn-ws/s3data_test.go
@@ -1,24 +1,14 @@
 package main
 
 import (
-	"bytes"
-	"context"
 	"fmt"
-	"github.com/aws/aws-sdk-go/aws"
-	"github.com/aws/aws-sdk-go/aws/client"
-	"github.com/aws/aws-sdk-go/aws/request"
-	"github.com/aws/aws-sdk-go/service/s3"
-	"github.com/aws/aws-sdk-go/service/s3/s3iface"
-	"io/ioutil"
 	"reflect"
-	"strings"
 	"testing"
 	"time"
 )
 
 var (
 	startTime, endTime Time
-	mockFileData       string = "some fake test data"
 )
 
 func init() {
@@ -33,197 +23,52 @@ func init() {
 	endTime = Time{startTime.Add(time.Hour * 1 * 24 * 312)}
 }
 
-// See https://docs.aws.amazon.com/sdk-for-go/api/service/s3/s3iface/ for s3iface docs and examples
-type mockS3Client struct {
-	s3iface.S3API
-}
-
-func newMockS3Client(p client.ConfigProvider, cfgs ...*aws.Config) s3iface.S3API {
-	mc := mockS3Client{}
-	return &mc
-}
-
-// mocked out ListObjectsV2 so we can give a known file list without connecting to S3
-func (c *mockS3Client) ListObjectsV2(*s3.ListObjectsV2Input) (*s3.ListObjectsV2Output, error) {
-	fileNames := []string{
-		"NZ.CHST.01.LOG.D.2013.251",
-		"NZ.CHST.01.LOG.D.2013.252",
-		"NZ.CHST.01.LOG.D.2013.253",
-		"NZ.ABCD.01.LOG.D.2013.251",
-		"NZ.ABCD.01.LOG.D.2013.252",
-		"NZ.ABCD.01.LOG.D.2013.253",
-	}
-	contents := []*s3.Object{
-		{Key: &fileNames[0]},
-		{Key: &fileNames[1]},
-		{Key: &fileNames[2]},
-		{Key: &fileNames[3]},
-		{Key: &fileNames[4]},
-		{Key: &fileNames[5]},
-	}
-	return &s3.ListObjectsV2Output{Contents: contents}, nil
-}
-
-func (c *mockS3Client) ListObjectsV2WithContext(ctx aws.Context, input *s3.ListObjectsV2Input, r ...request.Option) (*s3.ListObjectsV2Output, error) {
-	return c.ListObjectsV2(input)
-}
-
-func (c *mockS3Client) GetObject(input *s3.GetObjectInput) (*s3.GetObjectOutput, error) {
-	// Only implementing what we'll parse, the output.Body which needs to be a ReadCloser
-	rc := ioutil.NopCloser(strings.NewReader(mockFileData))
-	out := s3.GetObjectOutput{Body: rc}
-	return &out, nil
-}
-
-func (c *mockS3Client) GetObjectWithContext(ctx aws.Context, input *s3.GetObjectInput, r ...request.Option) (*s3.GetObjectOutput, error) {
-	return c.GetObject(input)
-}
-
-func TestMatchingFiles(t *testing.T) {
-	bucket := "FAKEBUCKET"
-
-	testCases := []struct {
-		p            fdsnDataselectV1
-		expectedKeys []string
-		expectedData []byte
-	}{
-		// Normally we'd use newS3DataSource but we want to construct our own mock s3 client so create a new value instead
-		{fdsnDataselectV1{
-			StartTime: endTime,
-			EndTime:   endTime,
-			Network:   []string{"NZ"},
-			Station:   []string{"CHST", "ABCD"},
-			Location:  []string{"01"},
-			Channel:   []string{"LOG"},
-		},
-			[]string{"NZ.CHST.01.LOG.D.2013.252", "NZ.ABCD.01.LOG.D.2013.252"},
-			[]byte(mockFileData),
-		},
-	}
-
-	for _, tc := range testCases {
-		t.Run(fmt.Sprintf("%v", tc.p), func(t *testing.T) {
-			ds := s3DataSource{bucket: bucket, params: tc.p, s3ClientFunc: newMockS3Client}
-
-			keys, err := ds.matchingKeys(context.Background())
-			if err != nil {
-				t.Fatal(err)
-			}
-
-			if !reflect.DeepEqual(keys, tc.expectedKeys) {
-				t.Errorf("Expected string slice %v but observed %v\n", tc.expectedKeys, keys)
-			}
-
-			for _, key := range tc.expectedKeys {
-				data, err := ds.getObject(context.Background(), key)
-				if err != nil {
-					t.Error(err)
-				}
-
-				if !bytes.Equal(data, tc.expectedData) {
-					t.Error("data different than expected")
-				}
-			}
-		})
-	}
-}
-
-func TestCommonString(t *testing.T) {
-	testCases := []struct {
-		input1, input2, wildcard, expected string
-	}{
-		{"aaaa", "aaab", "*", "aaa*"},
-		{"1234", "5678", "?", "????"},
-		{"2016", "2017", "?", "201?"},
-	}
-
-	for _, tc := range testCases {
-		t.Run(fmt.Sprintf("%s, %s, %s", tc.input1, tc.expected, tc.wildcard), func(t *testing.T) {
-			observed := commonString(tc.input1, tc.input2, tc.wildcard)
-			if observed != tc.expected {
-				t.Errorf("Expected string %s but observed %s", tc.expected, observed)
-			}
-		})
-	}
-}
-
-func TestCommonSlice(t *testing.T) {
-	// get the common prefix between a slice of input strings, all other chars being set to wildcard.
-	testCases := []struct {
-		inputs             []string
-		wildcard, expected string
-	}{
-		{[]string{"aaaa", "aaab"}, "*", "aaa*"},
-		{[]string{"aaaa", "aaab", "xyab"}, "*", "**a*"},
-		{[]string{"1234", "5678"}, "?", "????"},
-		{[]string{"2016", "2017"}, "?", "201?"},
-	}
-
-	for _, tc := range testCases {
-		t.Run(fmt.Sprintf("%s, %s, %s", tc.inputs, tc.expected, tc.wildcard), func(t *testing.T) {
-			observed := commonSlice(tc.inputs, tc.wildcard)
-			if observed != tc.expected {
-				t.Errorf("Expected string %s but observed %s", tc.expected, observed)
-			}
-		})
-	}
-}
-
 func TestRegexp(t *testing.T) {
 	testCases := []struct {
-		inputParams     s3DataSource
-		expectedPattern [][]string
-		expectedRegexp  []string
-		expectedPrefix  string
+		inputParams    s3DataSource
+		expectedRegexp []string
 	}{
 		{s3DataSource{
 			params: fdsnDataselectV1{
 				StartTime: startTime,
-				EndTime:   startTime,
+				EndTime:   endTime,
 				Network:   []string{"NZ"},
 				Station:   []string{"ABC"},
 				Location:  []string{"XYZ"},
 				Channel:   []string{"01"},
 			},
 		},
-			[][]string{{"NZ"}, {"ABC"}, {"XYZ"}, {"01"}, {"D"}, {"2012"}, {"306"}},
-			[]string{"(NZ)", "(ABC)", "(XYZ)", "(01)", "(D)", "(2012)", "(306)"},
-			"NZ.ABC.XYZ.01.D.2012.306",
+			[]string{"(^NZ$)", "(^ABC$)", "(^XYZ$)", "(^01$)"},
 		},
 
-		// using two different times, should get a different year and yearday
 		{s3DataSource{
 			params: fdsnDataselectV1{
-				StartTime: endTime,
-				EndTime:   startTime,
+				StartTime: startTime,
+				EndTime:   endTime,
 				Network:   []string{"NZ"},
 				Station:   []string{"AB*"},
-				Location:  []string{"?YZ"},
+				Location:  []string{"?YZ", "EF*"},
 				Channel:   []string{"0*"},
 			},
 		},
-			[][]string{{`NZ`}, {`AB*`}, {`?YZ`}, {`0*`}, {`D`}, {`201?`}, {`*`}},
-			[]string{`(NZ)`, `(AB\w*)`, `(\w{1}YZ)`, `(0\w*)`, `(D)`, `(201\w{1})`, `(\w*)`},
-			"NZ.AB",
+			[]string{`(^NZ$)`, `(^AB\w*$)`, `(^\w{1}YZ$)|(^EF\w*$)`, `(^0\w*$)`},
 		},
 	}
 
 	for _, tc := range testCases {
 		t.Run(fmt.Sprintf("%v", tc.inputParams), func(t *testing.T) {
-			observedPattern := tc.inputParams.searchPattern()
-			if !reflect.DeepEqual(observedPattern, tc.expectedPattern) {
-				t.Errorf("Expected string slice %v but observed %v", tc.expectedPattern, observedPattern)
-			}
-
-			observedRegexp := tc.inputParams.regexp()
+			net, sta, loc, cha, start, end := tc.inputParams.regexp()
+			observedRegexp := []string{net, sta, loc, cha}
 			if !reflect.DeepEqual(observedRegexp, tc.expectedRegexp) {
 				t.Errorf("Expected string %v but observed %v", tc.expectedRegexp, observedRegexp)
 			}
 
-			// the prefix used when querying files on S3 must stop at any wildcards in the key name
-			observedPrefix := tc.inputParams.prefix()
-			if observedPrefix != tc.expectedPrefix {
-				t.Errorf("Expected string %s but observed %s", tc.expectedPrefix, observedPrefix)
+			if !start.Equal(startTime.Time) {
+				t.Errorf("Expected time %v but observed %v", startTime, start)
+			}
+
+			if !end.Equal(endTime.Time) {
+				t.Errorf("Expected time %v but observed %v", endTime, end)
 			}
 		})
 	}

--- a/cmd/fdsn-ws/server_test.go
+++ b/cmd/fdsn-ws/server_test.go
@@ -14,6 +14,8 @@ var ts *httptest.Server
 func setup(t *testing.T) {
 	var err error
 
+	S3_BUCKET = os.Getenv("S3_BUCKET")
+
 	db, err = sql.Open("postgres", "host=localhost connect_timeout=300 user=fdsn_w password=test dbname=fdsn sslmode=disable statement_timeout=600000")
 	if err != nil {
 		t.Fatalf("ERROR: problem with DB config: %s", err)


### PR DESCRIPTION
This change should make this approach scale much better than previously as it avoids listing a large number of keys in S3.

- Removed a lot of code that listed and filtered the keys from an S3 bucket.  Replaced it with code that uses the holdings API.
- Added a function that populates the holdings for the integration tests that download from S3.  These add keys for existing objects in S3.  This lets us download the file and perform a complete integration test.
- Switched to using the production bucket fdsn-data.geonet.org.nz which is read-only.  We're using 2016 data which should be stable.

