### PR TITLE
Subtracting 24 hours from the start time in holdingsSearch

### DIFF
--- a/cmd/fdsn-ws/data_holdings.go
+++ b/cmd/fdsn-ws/data_holdings.go
@@ -92,7 +92,8 @@ func holdingsHandler(r *http.Request, h http.Header, b *bytes.Buffer) *weft.Resu
 // holdingsSearch searches for S3 keys matching the query.
 // network, station, channel, and location are matched using POSIX regular expressions.
 // https://www.postgresql.org/docs/9.3/static/functions-matching.html
-// start and end should be set for all queries.
+// start and end should be set for all queries.  24 hours will be subtracted from the Start time to include all records
+// in each day long file.
 func holdingsSearch(network, station, location, channel string, start, end time.Time) (keys []string, err error) {
 	var rows *sql.Rows
 
@@ -102,7 +103,7 @@ func holdingsSearch(network, station, location, channel string, start, end time.
 	AND channel ~ $3
 	AND location ~ $4)
 	SELECT DISTINCT ON (key) key FROM s JOIN fdsn.holdings USING (streampk) WHERE start_time >= $5 AND start_time <= $6`,
-		network, station, channel, location, start, end)
+		network, station, channel, location, start.Add(time.Hour*-24), end)
 	if err != nil {
 		return
 	}


### PR DESCRIPTION
This should include all keys during that day.  This should fix the little bug where a sub-day time window would return zero keys to read.