### PR TITLE
Travis build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -37,6 +37,6 @@ script:
 deploy:
    - provider: script
      skip_cleanup: true
-     script: ./build-push.sh fdsn-quake-consumer fdsn-ws fdsn-holdings-consumer
+     script: ./build-push.sh fdsn-quake-consumer fdsn-ws fdsn-holdings-consumer fdsn-ws-nrt slink-db
      on: 
        branch: master 

--- a/build.sh
+++ b/build.sh
@@ -48,7 +48,7 @@ do
 
     # only enable Cgo for executables that require it
     enable_cgo=0
-    if [ ${i} = "fdsn-ws" ]; then
+    if [ ${i} = "fdsn-ws" ] || [ ${i} = "fdsn-holdings-consumer" ] || [ ${i} = "slink-db" ]; then
         enable_cgo=1
     fi
 


### PR DESCRIPTION
Enable cgo build in Docker for fdsn-holdings-consumer and slink-db
Add publishing slink-db and fdsn-ws-nrt containers to ECR.