### PR TITLE
FDSN station radius filter as requested in #50.

### DIFF
--- a/cmd/fdsn-ws/fdsn_station_test.go
+++ b/cmd/fdsn-ws/fdsn_station_test.go
@@ -113,8 +113,8 @@ func TestStationFilter(t *testing.T) {
 	v = make(map[string][]string)
 	v.Set("latitude", "-38.6")
 	v.Set("longitude", "176.1")
-	v.Set("minradius", "1")
-	v.Set("maxradius", "20")
+	v.Set("maxradius", "0.5")
+
 	if e, err = parseStationV1(v); err != nil {
 		t.Error(err)
 	}
@@ -132,7 +132,7 @@ func TestStationFilter(t *testing.T) {
 	}
 
 	// test if minradius works
-	v.Set("minradius", "10")
+	v.Set("minradius", "0.1")
 	if e, err = parseStationV1(v); err != nil {
 		t.Error(err)
 	}

--- a/cmd/fdsn-ws/routes_test.go
+++ b/cmd/fdsn-ws/routes_test.go
@@ -50,9 +50,9 @@ var routes = wt.Requests{
 	{ID: wt.L(), URL: "/fdsnws/station/1/query?level=channel&starttime=1900-01-01T00:00:00&format=text", Content: "text/plain"},
 	{ID: wt.L(), URL: "/fdsnws/station/1/query?format=y", Content: "text/plain", Status: http.StatusBadRequest},
 	{ID: wt.L(), URL: "/fdsnws/station/1/query?net=*&level=network&format=xml", Content: "application/xml"},
-	{ID: wt.L(), URL: "/fdsnws/station/1/query?lat=-38.6&lon=176.1", Content: "text/plain", Status: http.StatusBadRequest},
-	{ID: wt.L(), URL: "/fdsnws/station/1/query?lat=-38.6&lon=176.1&maxradius=100", Content: "application/xml"},
-	{ID: wt.L(), URL: "/fdsnws/station/1/query?lat=-38.6&lon=176.1&maxradius=100&minradius=1", Content: "application/xml"},
+	{ID: wt.L(), URL: "/fdsnws/station/1/query?lat=-38.6&lon=176.1", Content: "application/xml"},
+	{ID: wt.L(), URL: "/fdsnws/station/1/query?lat=-38.6&lon=176.1&maxradius=1.0", Content: "application/xml"},
+	{ID: wt.L(), URL: "/fdsnws/station/1/query?lat=-38.6&lon=176.1&maxradius=1.0&minradius=0.1", Content: "application/xml"},
 	// supporting the includeavailability parameter is optional.  Some clients send the value `false` which is the default.
 	// allow for this by ignoring includeavailability=false
 	{ID: wt.L(), URL: "/fdsnws/station/1/query?net=*&level=network&format=xml&includeavailability=false", Content: "application/xml"},


### PR DESCRIPTION
Fix - The units of maxradius and minradius are degree
Fix - maxradius and minradius have default value.

@nbalfour 
To find the difference of 2 points in degrees: we first get the distance of 2 points in the unit of km,  then divide it with 111 to get the degrees. Is this OK for you?