### PR TITLE
Improve cache usage.

### DIFF
--- a/cmd/fdsn-ws-nrt/env.list
+++ b/cmd/fdsn-ws-nrt/env.list
@@ -10,3 +10,6 @@ DB_MAX_OPEN_CONNS=30
 MTR_SERVER=
 MTR_USER=
 MTR_KEY=
+
+# size for the RAM base miniSEED record cache in GB
+CACHE_SIZE=4

--- a/cmd/fdsn-ws-nrt/fdsn_dataselect.go
+++ b/cmd/fdsn-ws-nrt/fdsn_dataselect.go
@@ -63,7 +63,7 @@ func fdsnDataselectV1Handler(r *http.Request, w http.ResponseWriter) *weft.Resul
 			return weft.InternalServerError(err)
 		}
 		for _, k := range keys {
-			err = record.Get(nil, k, groupcache.AllocatingByteSliceSink(&rec))
+			err = recordCache.Get(nil, k, groupcache.AllocatingByteSliceSink(&rec))
 			switch err {
 			case nil:
 				w.Write(rec)


### PR DESCRIPTION
Improve the use of the RAM cache for miniSEED records:
* back fill the cache on start up.
* actively fill the cache going forwards.

I've added the env var CACHE_SIZE to prod already so this can merge anytime.