### PR TITLE
Simplify cache priming

### DIFF
--- a/cmd/fdsn-ws-nrt/data_nrt.go
+++ b/cmd/fdsn-ws-nrt/data_nrt.go
@@ -51,13 +51,12 @@ func holdingsSearchNrt(d fdsn.DataSearch) ([]string, error) {
 }
 
 // primeCache fills the miniSEED record cache from the DB.  It fills for records
-// more recent than start up to maxRecords records.  This can be used to limit
-// cache priming to be less than the amount of RAM assigned to the cache.
-func primeCache(start time.Time, maxRecords int64) error {
+// more recent than start.
+func primeCache(start time.Time) error {
 	rows, err := db.Query(`WITH r AS (SELECT streamPk, start_time
 				FROM fdsn.record WHERE start_time > $1)
 				SELECT network, station, channel, location, start_time FROM fdsn.stream JOIN r USING (streamPK)
-				ORDER BY start_time DESC LIMIT $2`, start, maxRecords)
+				ORDER BY start_time DESC`, start)
 	if err != nil {
 		return err
 	}

--- a/cmd/fdsn-ws-nrt/server.go
+++ b/cmd/fdsn-ws-nrt/server.go
@@ -14,8 +14,6 @@ import (
 	"time"
 )
 
-const recordLength = 512 // miniSEED record length in bytes
-
 var (
 	db          *sql.DB
 	decoder     = schema.NewDecoder() // decoder for URL queries.
@@ -78,13 +76,11 @@ func main() {
 	go func() {
 		ticker := time.Tick(time.Second * 30)
 
-		maxRecords := int64(cacheSize / recordLength)
-
 		for {
 			select {
 			case <-ticker:
 				t := mtrapp.Start()
-				err := primeCache(time.Now().UTC().Add(time.Second*-40), maxRecords)
+				err := primeCache(time.Now().UTC().Add(time.Second * -40))
 				if err != nil {
 					log.Printf("priming cache %s", err.Error())
 				}


### PR DESCRIPTION
Now only prime cache for small time chunks.  There is no large
backfilling.  Remove the record count limit on the cache priming.