### PR TITLE
Remove unnecessary trailing null trimming after mseed lib updated.

### DIFF
--- a/cmd/fdsn-slink-db/app.go
+++ b/cmd/fdsn-slink-db/app.go
@@ -7,7 +7,6 @@ import (
 	"github.com/GeoNet/kit/mseed"
 	"github.com/pkg/errors"
 	"log"
-	"strings"
 	"time"
 )
 
@@ -78,10 +77,10 @@ func (a *app) save(inbound chan []byte) {
 
 			for {
 				err = a.saveRecord(record{
-					network:      strings.Trim(msr.Network(), "\x00"),
-					station:      strings.Trim(msr.Station(), "\x00"),
-					channel:      strings.Trim(msr.Channel(), "\x00"),
-					location:     strings.Trim(msr.Location(), "\x00"),
+					network:      msr.Network(),
+					station:      msr.Station(),
+					channel:      msr.Channel(),
+					location:     msr.Location(),
 					start:        msr.Starttime(),
 					latency_tx:   time.Now().UTC().Sub(msr.Endtime()).Seconds(),
 					latency_data: time.Now().UTC().Sub(msr.Starttime()).Seconds(),

--- a/cmd/fdsn-ws-nrt/data_nrt_test.go
+++ b/cmd/fdsn-ws-nrt/data_nrt_test.go
@@ -7,7 +7,6 @@ import (
 	"github.com/golang/groupcache"
 	"io"
 	"os"
-	"strings"
 	"testing"
 	"time"
 )
@@ -76,19 +75,19 @@ func TestGetRecord(t *testing.T) {
 		t.Error(err)
 	}
 
-	if strings.Trim(msr.Network(), "\x00") != "NZ" {
+	if msr.Network() != "NZ" {
 		t.Errorf("expected network NZ got %s", msr.Network())
 	}
 
-	if strings.Trim(msr.Station(), "\x00") != "ABAZ" {
+	if msr.Station() != "ABAZ" {
 		t.Errorf("expected station ABAZ got %s", msr.Station())
 	}
 
-	if strings.Trim(msr.Channel(), "\x00") != "EHE" {
+	if msr.Channel() != "EHE" {
 		t.Errorf("expected channel EHE got %s", msr.Channel())
 	}
 
-	if strings.Trim(msr.Location(), "\x00") != "10" {
+	if msr.Location() != "10" {
 		t.Errorf("expected location 10 got %s", msr.Location())
 	}
 
@@ -249,10 +248,10 @@ func testLoad(file string, t testing.TB) {
 			continue
 		}
 
-		network := strings.Trim(msr.Network(), "\x00")
-		station := strings.Trim(msr.Station(), "\x00")
-		channel := strings.Trim(msr.Channel(), "\x00")
-		location := strings.Trim(msr.Location(), "\x00")
+		network := msr.Network()
+		station := msr.Station()
+		channel := msr.Channel()
+		location := msr.Location()
 
 		// not bothering setting min and max
 
@@ -312,10 +311,10 @@ func testLoadFirst(file string, t testing.TB) {
 		return
 	}
 
-	network := strings.Trim(msr.Network(), "\x00")
-	station := strings.Trim(msr.Station(), "\x00")
-	channel := strings.Trim(msr.Channel(), "\x00")
-	location := strings.Trim(msr.Location(), "\x00")
+	network := msr.Network()
+	station := msr.Station()
+	channel := msr.Channel()
+	location := msr.Location()
 
 	// not bothering setting min and max
 

--- a/internal/holdings/holdings.go
+++ b/internal/holdings/holdings.go
@@ -4,7 +4,6 @@ package holdings
 import (
 	"github.com/GeoNet/kit/mseed"
 	"io"
-	"strings"
 	"time"
 )
 
@@ -42,10 +41,10 @@ func SingleStream(r io.Reader) (Holding, error) {
 	}
 
 	h := Holding{
-		Network:    strings.Trim(msr.Network(), "\x00"),
-		Station:    strings.Trim(msr.Station(), "\x00"),
-		Channel:    strings.Trim(msr.Channel(), "\x00"),
-		Location:   strings.Trim(msr.Location(), "\x00"),
+		Network:    msr.Network(),
+		Station:    msr.Station(),
+		Channel:    msr.Channel(),
+		Location:   msr.Location(),
 		Start:      msr.Starttime(),
 		NumSamples: int(msr.Numsamples()),
 	}

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -42,22 +42,22 @@
 			"tree": true
 		},
 		{
-			"checksumSHA1": "EiYTGjWEG36hVCdQ8uFNJpxzepw=",
+			"checksumSHA1": "kd7ow9jrUio4gc74DV38kl2cMPA=",
 			"path": "github.com/GeoNet/kit/mseed",
-			"revision": "2c00bd8989f810e3c3746c01cda4bcfc1bb1f559",
-			"revisionTime": "2017-05-29T05:10:37Z"
+			"revision": "5203fd0a601edb389818488f5d2ee5fb4ee9d477",
+			"revisionTime": "2017-06-28T22:00:05Z"
 		},
 		{
 			"checksumSHA1": "3JsW/vlMhZWOm9tAS+ZoOYUy8aQ=",
 			"path": "github.com/GeoNet/kit/sc3ml",
-			"revision": "2f9da4f307c2035e47546391da8701a642fc9598",
-			"revisionTime": "2017-02-06T08:02:36Z"
+			"revision": "5203fd0a601edb389818488f5d2ee5fb4ee9d477",
+			"revisionTime": "2017-06-28T22:00:05Z"
 		},
 		{
 			"checksumSHA1": "2+qgbnzd5tfpcwZols7hyOQjzu8=",
 			"path": "github.com/GeoNet/kit/slink",
-			"revision": "2c00bd8989f810e3c3746c01cda4bcfc1bb1f559",
-			"revisionTime": "2017-05-29T05:10:37Z"
+			"revision": "5203fd0a601edb389818488f5d2ee5fb4ee9d477",
+			"revisionTime": "2017-06-28T22:00:05Z"
 		},
 		{
 			"checksumSHA1": "FcAtIa3dCgJBin+SrFiTOEU/bsA=",


### PR DESCRIPTION
As requested in #67 .
The old mseed library returns strings with null terminated so we'll have to post processing them. Now the library has been fixed.