### PR TITLE
Fix for issue #117

### DIFF
--- a/cmd/fdsn-ws-nrt/fdsn_dataselect.go
+++ b/cmd/fdsn-ws-nrt/fdsn_dataselect.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"bytes"
+	"fmt"
 	"github.com/GeoNet/fdsn/internal/fdsn"
 	"github.com/GeoNet/kit/weft"
 	"github.com/golang/groupcache"
@@ -92,6 +93,10 @@ func fdsnDataselectV1Handler(r *http.Request, w http.ResponseWriter) (int64, err
 				return 0, err
 			}
 		}
+	}
+
+	if written == 0 {
+		return 0, weft.StatusError{Code: params[0].NoData, Err: fmt.Errorf("%s", "no results for specified query")}
 	}
 
 	return int64(written), nil


### PR DESCRIPTION
#117

Ensure that dataselect follows the FDSN standard by returning a 204 (or a 404 if specified) when no data is found for the requested query.