### PR TITLE
Fix station/dataselect query parameter

### DIFF
--- a/cmd/fdsn-ws-nrt/fdsn_dataselect.go
+++ b/cmd/fdsn-ws-nrt/fdsn_dataselect.go
@@ -61,7 +61,6 @@ func fdsnDataselectV1Handler(r *http.Request, w http.ResponseWriter) (int64, err
 		return 0, weft.StatusError{Code: http.StatusMethodNotAllowed}
 	}
 
-	var err error
 	var keys []string
 	var rec []byte
 
@@ -71,9 +70,12 @@ func fdsnDataselectV1Handler(r *http.Request, w http.ResponseWriter) (int64, err
 	w.Header().Set("Content-Type", "application/vnd.fdsn.mseed")
 	var n int
 	var written int
-
 	for _, v := range params {
-		keys, err = holdingsSearchNrt(v.Regexp())
+		s, err := v.Regexp()
+		if err != nil {
+			return 0, err
+		}
+		keys, err = holdingsSearchNrt(s)
 		if err != nil {
 			return 0, err
 		}

--- a/cmd/fdsn-ws/fdsn_dataselect.go
+++ b/cmd/fdsn-ws/fdsn_dataselect.go
@@ -104,8 +104,10 @@ func fdsnDataMetricsV1Handler(r *http.Request, h http.Header, b *bytes.Buffer) e
 	var metrics []metric
 
 	for _, v := range params {
-		d := v.Regexp()
-
+		d, err := v.Regexp()
+		if err != nil {
+			return err
+		}
 		m, err := metricsSearch(d)
 		if err != nil {
 			return err
@@ -169,8 +171,10 @@ func fdsnDataselectV1Handler(r *http.Request, w http.ResponseWriter) (int64, err
 	var files int
 
 	for _, v := range params {
-		d := v.Regexp()
-
+		d, err := v.Regexp()
+		if err != nil {
+			return 0, err
+		}
 		keys, err := holdingsSearch(d)
 		if err != nil {
 			return 0, err

--- a/internal/fdsn/dataselect_test.go
+++ b/internal/fdsn/dataselect_test.go
@@ -2,6 +2,7 @@ package fdsn_test
 
 import (
 	"bytes"
+	"fmt"
 	"github.com/GeoNet/fdsn/internal/fdsn"
 	"reflect"
 	"testing"
@@ -56,5 +57,52 @@ NZ ABCD 10 E*? 2017-01-02T00:00:00 2017-01-03T00:00:00
 
 	if !reflect.DeepEqual(dsq, dsqExpected) {
 		t.Errorf("structs do not match, expected: %v, observed: %v", dsqExpected, dsq)
+	}
+}
+
+func TestGenRegex(t *testing.T) {
+	// normal case
+	r, err := fdsn.GenRegex([]string{"ABA0"}, false)
+	if err != nil {
+		t.Error(err)
+	}
+	if len(r) != 1 || r[0] != "^ABA0$" {
+		t.Error(fmt.Sprintf("expect ^ABA0$ got %+v", r[0]))
+	}
+
+	// "--" empty location
+	r, err = fdsn.GenRegex([]string{"--"}, true)
+	if err != nil {
+		t.Error(err)
+	}
+	if len(r) != 1 || r[0] != "^\\s{2}$" {
+		t.Error(fmt.Sprintf("expect ^\\s{2}$ got %+v", r[0]))
+	}
+
+	// "?" and "*" special
+	r, err = fdsn.GenRegex([]string{"A?Z*"}, false)
+	if err != nil {
+		t.Error(err)
+	}
+	if len(r) != 1 || r[0] != "^A.Z.*$" {
+		t.Error(fmt.Sprintf("expect ^A.Z.*$ got %+v", r[0]))
+	}
+
+	// other regex special chars escaped
+	// (only test some regex chars to make sure it does quote)
+	r, err = fdsn.GenRegex([]string{"*\\^{]"}, false)
+	if err != nil {
+		t.Error(err)
+	}
+	if len(r) != 1 || r[0] != "^.*\\\\\\^\\{\\]$" {
+		t.Error(fmt.Sprintf("expect ^.*\\\\\\^\\{\\]$ got %+v", r[0]))
+	}
+
+	r, err = fdsn.GenRegex([]string{"[E,H]H?"}, false)
+	if err != nil {
+		t.Error(err)
+	}
+	if len(r) != 1 || r[0] != "^\\[E,H\\]H.$" {
+		t.Error(fmt.Sprintf("expect ^\\[E,H\\]H.$ got %+v", r[0]))
 	}
 }


### PR DESCRIPTION
For ticket https://github.com/GeoNet/tickets/issues/1728.

FDSN's spec allows ALL ASCII CHARS as query parameter for network,station,channel, and location. And only "*" and "?" has special meanings so all other chars is allowed but they'll be quoted with backslash if they are part of regex meta chars.

SQL injection check:
In fdsn repo, all database queries are using parameterised db.Query() or db.Exec() so should be safe from SQL injection. (Except sc3ml is combining values() string but it's only taking integer values) 