### PR TITLE
Gather the CA certificates and zoneinfo resources from alpine:3.7

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -19,6 +19,9 @@ fi
 # code will be compiled in this container
 BUILD_CONTAINER=golang:1.9.1-alpine
 
+# dependent resources will be gathered from this container
+RESOURCE_CONTAINER=alpine:3.7
+
 DOCKER_TMP=docker-build-tmp
 
 mkdir -p $DOCKER_TMP
@@ -35,7 +38,7 @@ mkdir -p ${DOCKER_TMP}/etc/ssl/certs
 mkdir -p ${DOCKER_TMP}/usr/share
 
 # Assemble common resource for ssl and timezones from the build container
-docker run --rm -v ${PWD}:${PWD} ${BUILD_CONTAINER} \
+docker run --rm -v ${PWD}:${PWD} ${RESOURCE_CONTAINER} \
     /bin/ash -c "apk add --update ca-certificates tzdata && \
     cp /etc/ssl/certs/ca-certificates.crt ${PWD}/${DOCKER_TMP}/etc/ssl/certs && \
     cp -Ra /usr/share/zoneinfo ${PWD}/${DOCKER_TMP}/usr/share"


### PR DESCRIPTION
## Proposed Changes

Required as part of AWS SQS, CA updates.

Changes proposed in this pull request:

- Modify build scripts to source required container resources (CA certificates and tzdata) from a separate container (`alpine:3.7`).

## Production Changes

The following production changes are required to deploy these changes:

- Rebuild and deploy:
  - fdsn-quake-consumer
  - fdsn-holdings-consumer

## Review

Check the box that applies to this code review.  If necessary please seek help with adding a checklist guide for the reviewer.
When assigning the code review please consider the expertise needed to review the changes.

- [ ] This is a content (documentation, web page etc) only change.
- [x] This is a minor change (meta data, bug fix, improve test coverage etc).
- [ ] This is a larger change (new feature, significant refactoring etc).  Please use the code review guidelines to add a checklist below to guide the code reviewer.
