### PR TITLE
Limit Dataselect Queries

### DIFF
--- a/cmd/fdsn-ws/assets/fdsn-ws-dataselect.html
+++ b/cmd/fdsn-ws/assets/fdsn-ws-dataselect.html
@@ -21,7 +21,7 @@
 
 <h2>Feature Notes</h2>
 <ul>
-    <li>The result set is limited to 20,000 files.  Queries that would return more than 20,000 files receive an HTTP
+    <li>The result set is limited to 60 files OR 30 minutes. Queries that would return more than this limit receive an HTTP
         413 response and will need to be broken in to smaller queries.</li>
 </ul>
 </body>


### PR DESCRIPTION
Related to https://github.com/GeoNet/tickets/issues/3759

This PR restricts Dataselect queries to either 60 days (more specifically day files) (2 months) OR a maximum of 30 minutes. 

This implementation assumes it is ok to request those 60 days in any combination (e.g. 2days of each channel across 30 channels OR 60 days of 1 channel). i.e. as long as: 
```
[num of channels] * [num of days OR partial days] <= 60 OR longest request <= 30mins
```
The request will be allowed.

It does not change limits on the other queries (event or station). 
Data metrics are limited to maximum files of 60 but have no 30minute 'grace' window in this implementation.