### PR TITLE
apply time filter on channel for level response

### DIFF
--- a/cmd/fdsn-ws/fdsn_station.go
+++ b/cmd/fdsn-ws/fdsn_station.go
@@ -771,12 +771,19 @@ func (c *ChannelType) doFilter(params []fdsnStationV1Search) bool {
 }
 
 func (v fdsnStationV1Search) validStartEnd(start, end time.Time, level int) bool {
-	// For start/end, the "no-value" could be "0001-01-01T00:00:00" or "9999-01-01T00:00:00"
-	if v.LevelValue != level {
-		// Not validating furthur for different level
+	/**
+	 * #GeoNet/tickets/issues/4793
+	 * basically apply time filter for the intended level only, because
+	 * 1. network, stations and channels have different time scope, a time filter intended for station/channel/response
+	 *    is not supposed to apply on network/stations,
+	 * 2. while chanel and response have the same time scope (response doesn't have time attributes at all)
+	 *    a time filter specified for response level need to apply on the parent channel element
+	 */
+	if v.LevelValue != level && (level == STATION_LEVEL_NETWORK || level == STATION_LEVEL_STATION) {
+		// skip time filter
 		return true
 	}
-
+	// For start/end, the "no-value" could be "0001-01-01T00:00:00" or "9999-01-01T00:00:00"
 	if v.StartTime.Time != zeroDateTime {
 		switch v.startMode {
 		case ONBEFOREEND: // startTime


### PR DESCRIPTION
## Proposed Changes

Resolves #GeoNet/tickets/issues/4793

Changes proposed in this pull request:

-  apply time filter on `channel` for `level==response`

## Production Changes

The following production changes are required to deploy these changes:

- None

## Review

Check the box that applies to this code review.  If necessary please seek help with adding a checklist guide for the reviewer.
When assigning the code review please consider the expertise needed to review the changes.

- [ ] This is a content (documentation, web page etc) only change.
- [x] This is a minor change (meta data, bug fix, improve test coverage etc).
- [ ] This is a larger change (new feature, significant refactoring etc).  Please use the code review guidelines to add a checklist below to guide the code reviewer.


### Code Review Guide

*Insert check list here if needed.*