### PR TITLE
Filter channels parameter.

### DIFF
--- a/cmd/fdsn-ws-nrt/fdsn_dataselect.go
+++ b/cmd/fdsn-ws-nrt/fdsn_dataselect.go
@@ -78,8 +78,9 @@ func fdsnDataselectV1Handler(r *http.Request, w http.ResponseWriter) (int64, err
 	for _, v := range params {
 		s, err := v.Regexp()
 		if err != nil {
-			return 0, err
+			return 0, weft.StatusError{Code: http.StatusBadRequest, Err: err}
 		}
+
 		keys, err = holdingsSearchNrt(s)
 		if err != nil {
 			return 0, err

--- a/cmd/fdsn-ws-nrt/routes_test.go
+++ b/cmd/fdsn-ws-nrt/routes_test.go
@@ -30,6 +30,17 @@ var routes = wt.Requests{
 	{ID: wt.L(), URL: "/fdsnws/dataselect/1/query?starttime=1900-01-09T00:00:00&endtime=1900-01-09T01:00:00&network=NZ&station=CHST&location=01&channel=LOG",
 		Content: "application/vnd.fdsn.mseed",
 		Status:  http.StatusNoContent},
+	// spam
+	{ID: wt.L(), URL: "/fdsnws/dataselect/1/query?channel=LOG&endtime=1900-01-09T01:00:00&location=01&network=c:/Windows/system.ini&starttime=1900-01-09T00:00:00&station=CHST",
+		Status: http.StatusBadRequest},
+	{ID: wt.L(), URL: "/fdsnws/dataselect/1/query?channel=LOG&endtime=1900-01-09T01%3A00%3A00&location=01&network=NZ&starttime=1900-01-09T00%3A00%3A00&station=c%3A%2FWindows%2Fsystem.ini",
+		Status: http.StatusBadRequest},
+	{ID: wt.L(), URL: "/fdsnws/dataselect/1/query?channel=LOG&endtime=1900-01-09T01%3A00%3A00&location=01&network=c%3A%2FWindows%2Fsystem.ini&starttime=1900-01-09T00%3A00%3A00&station=CHST",
+		Status: http.StatusBadRequest},
+	{ID: wt.L(), URL: "/fdsnws/dataselect/1/query?channel=LOG&endtime=c%3A%2FWindows%2Fsystem.ini&location=01&network=*&starttime=1900-01-09T00%3A00%3A00&station=CHST",
+		Status: http.StatusBadRequest},
+	{ID: wt.L(), URL: "/fdsnws/dataselect/1/query?unknownparam=1",
+		Status: http.StatusBadRequest},
 	// post
 	{ID: wt.L(), Method: "POST", URL: "/fdsnws/dataselect/1/query", PostBody: []byte("NZ ABAZ 10 EHE 2016-03-19T00:00:00 2016-03-19T01:00:00"),
 		Content: "application/vnd.fdsn.mseed"},

--- a/cmd/fdsn-ws/fdsn_dataselect.go
+++ b/cmd/fdsn-ws/fdsn_dataselect.go
@@ -182,7 +182,7 @@ func fdsnDataselectV1Handler(r *http.Request, w http.ResponseWriter) (int64, err
 
 		d, err := v.Regexp()
 		if err != nil {
-			return 0, err
+			return 0, weft.StatusError{Code: http.StatusBadRequest, Err: err}
 		}
 		keys, err := holdingsSearch(d)
 		if err != nil {

--- a/cmd/fdsn-ws/routes_test.go
+++ b/cmd/fdsn-ws/routes_test.go
@@ -63,6 +63,14 @@ var routes = wt.Requests{
 		Status: http.StatusNoContent},
 	{ID: wt.L(), URL: "/metrics/fdsnws/dataselect/1/query?starttime=2016-01-09T00:00:00&endtime=2016-01-09T23:00:00&network=NZ&station=CHST&location=01&channel=LOG"},
 
+	// spam
+	{ID: wt.L(), URL: "/fdsnws/dataselect/1/query?channel=LOG&endtime=1900-01-09T01:00:00&location=01&network=c:/Windows/system.ini&starttime=1900-01-09T00:00:00&station=CHST",
+		Status: http.StatusBadRequest},
+	{ID: wt.L(), URL: "/fdsnws/dataselect/1/query?channel=LOG&endtime=1900-01-09T01%3A00%3A00&location=01&network=NZ&starttime=1900-01-09T00%3A00%3A00&station=c%3A%2FWindows%2Fsystem.ini",
+		Status: http.StatusBadRequest},
+	{ID: wt.L(), URL: "/fdsnws/dataselect/1/query?channel=LOG&endtime=1900-01-09T01%3A00%3A00&location=01&network=c%3A%2FWindows%2Fsystem.ini&starttime=1900-01-09T00%3A00%3A00&station=CHST",
+		Status: http.StatusBadRequest},
+
 	{ID: wt.L(), URL: "/soh"},
 }
 

--- a/internal/fdsn/dataselect_test.go
+++ b/internal/fdsn/dataselect_test.go
@@ -88,21 +88,25 @@ func TestGenRegex(t *testing.T) {
 		t.Error(fmt.Sprintf("expect ^A.Z.*$ got %+v", r[0]))
 	}
 
-	// other regex special chars escaped
-	// (only test some regex chars to make sure it does quote)
-	r, err = fdsn.GenRegex([]string{"*\\^{]"}, false)
+	// "--" (exactly 2 hyphens) means empty in FDSN
+	_, err = fdsn.GenRegex([]string{"--"}, false)
 	if err != nil {
-		t.Error(err)
-	}
-	if len(r) != 1 || r[0] != "^.*\\\\\\^\\{\\]$" {
-		t.Error(fmt.Sprintf("expect ^.*\\\\\\^\\{\\]$ got %+v", r[0]))
+		t.Error(fmt.Sprintf("expect to passed but rejected"))
 	}
 
-	r, err = fdsn.GenRegex([]string{"[E,H]H?"}, false)
-	if err != nil {
-		t.Error(err)
+	_, err = fdsn.GenRegex([]string{"---"}, false)
+	if err == nil {
+		t.Error(fmt.Sprintf("expect to rejected but passed"))
 	}
-	if len(r) != 1 || r[0] != "^\\[E,H\\]H.$" {
-		t.Error(fmt.Sprintf("expect ^\\[E,H\\]H.$ got %+v", r[0]))
+
+	// block all other chars, including valid regex since we're not supporting regex
+	_, err = fdsn.GenRegex([]string{"*\\^{]"}, false)
+	if err == nil {
+		t.Error(fmt.Sprintf("expect to rejected but passed."))
+	}
+
+	_, err = fdsn.GenRegex([]string{"[E,H]H?"}, false)
+	if err == nil {
+		t.Error(fmt.Sprintf("expect to rejected but passed."))
 	}
 }


### PR DESCRIPTION
Reject unreasonable query parameters for `network`, `station`, `location`, and `channel` parameter - that means we're rejecting regex query parameters and only allowing `*`, `?`, `--` .
Previously we accept those parameters and returns with 204 (empty result).