### PR TITLE
Fix parameter error and test tool

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,4 +84,12 @@ make
 
 Build.sh will automatically re-build these C libraries before building any Go executables in Docker.
 
+## Test tool
 
+A test bash script `fdsn-batch-test.sh` (loads URLs from `fdsn-test-urls.txt`) can used to test against both FDSN and FDSN-NRT web service.
+
+For tests expecting http response status code other than 200, append `;;{expected_http_code}` after the URL, for example:
+```
+http://service.geonet.org.nz/fdsnws/dataselect/1/query?network=NZ&sta=RBCT&channel=????&starttime=2018-05-15T23:45:00&endtime=2018-05-15T23:45:10;;204
+```
+The test script will test the URL to see if the responsed http status is 204.

--- a/fdsn-batch-test.sh
+++ b/fdsn-batch-test.sh
@@ -1,0 +1,55 @@
+#!/bin/sh
+input="fdsn-test-urls.txt"
+list_placeholder1="\${List1}"
+list_placeholder2="\${List2}"
+list1="ABAZ,AKCZ,ALRZ,AMCZ,ANWZ,ARAZ,ARCZ,ARHZ,AWAZ,BHHZ,CAW,CKHZ,CMWZ,CNGZ,CPWZ,CRSZ,DREZ,DUWZ,DVHZ,EDRZ,EPAZ,ETAZ,GCSZ,HBAZ,HLRZ,HOWZ,HRRZ,HSRZ,KAHZ,KARZ,KATZ,KBAZ,KIW,KMRZ,KRHZ,KRVZ,KUTZ,KWHZ,LIRZ,LREZ,MARZ,MBAZ,MCHZ,MHCZ,MHEZ,MHGZ,MKRZ,MOVZ,MRHZ,MRNZ,MSWZ,MTHZ,MTVZ,MTW,MUGZ,MYRZ,NBEZ,NEZ,NGRZ,NGZ"
+list2="WEL,WEL,WEL,WEL,WEL,WEL,WEL,WEL"
+# firstly run through the test (should be against service.geonet.org.nz)
+while IFS= read -r line
+do
+  if ! [[ $line = \#* ]] && ! [[ -z $line ]] ; then
+    tk=(${line//;;/ })
+    if (( ${#tk[*]} > 1 )) ; then
+      res="${tk[1]}"
+    else
+      res="200"
+    fi
+    line=${tk[0]/$list_placeholder1/$list1}  # replace stations
+    line=${line/$list_placeholder2/$list2}  # replace stations
+    echo "expecting $res for $line"
+    r=$(curl -f --write-out %{http_code} -s --output /dev/null "$line")
+    if ! [ $? -eq 0 ] || ! [ $r -eq ${res} ] ; then
+        echo "Error $line expect $res got result $r"
+        exit 1
+    fi
+  fi
+done < "$input"
+
+# now do nrt
+service="service.geonet.org.nz"
+service_nrt="service-nrt.geonet.org.nz"
+sample_date="2018-05-15"
+nrt_date=$(date -v-1d +'%Y-%m-%d') # 1 day ago
+echo "NRT test date: $nrt_date"
+
+while IFS= read -r line
+do
+  if ! [[ $line = \#* ]] && ! [[ -z $line ]] ; then
+    tk=(${line//;;/ })
+    if (( ${#tk[*]} > 1 )) ; then
+      res="${tk[1]}"
+    else
+      res="200"
+    fi
+    line=${tk[0]/$list_placeholder1/$list1}  # replace stations
+    line=${line/$list_placeholder2/$list2}  # replace stations
+    line=${line/$service/$service_nrt}  # replace server name to nrt
+    line=${line//$sample_date/$nrt_date} # replace date to 1 day ago
+    echo "$line"
+    r=$(curl -f --write-out %{http_code} -s --output /dev/null "$line")
+    if ! [ $? -eq 0 ] || ! [ $r -eq ${res} ] ; then
+        echo "Error $line expect $res got result $r"
+        exit 1
+    fi
+  fi
+done < "$input"

--- a/fdsn-test-urls.txt
+++ b/fdsn-test-urls.txt
@@ -1,0 +1,80 @@
+#FDSN Queries options tests (10 seconds of data only)
+#For tests expecting http response status code other than 200, append ";;{expected_http_code}" after the URL.
+#  Check example noted with "# This should fail (channels are 3 ?)"
+
+##### Locationcode queries
+# Classic Listing
+http://service.geonet.org.nz/fdsnws/dataselect/1/query?network=NZ&sta=WEL&location=00,10,11,20,21&starttime=2018-05-15T23:45:00&endtime=2018-05-15T23:45:10
+http://service.geonet.org.nz/fdsnws/dataselect/1/query?network=NZ&sta=WEL&location=00,10,11,20,21&starttime=2018-05-15T23:45:00&endtime=2018-05-15T23:45:10
+# TODO: add "--" to the location list for the 2 tests above after fix deployed.
+http://service.geonet.org.nz/fdsnws/dataselect/1/query?network=NZ&sta=WEL&location=00,10,11,20,21,22&starttime=2018-05-15T23:45:00&endtime=2018-05-15T23:45:10
+http://service.geonet.org.nz/fdsnws/dataselect/1/query?network=NZ&sta=RBCT&location=30,40&starttime=2018-05-15T23:45:00&endtime=2018-05-15T23:45:10
+
+# Wilcard test
+http://service.geonet.org.nz/fdsnws/dataselect/1/query?network=NZ&sta=RBCT&location=3?,4?&starttime=2018-05-15T23:45:00&endtime=2018-05-15T23:45:10
+http://service.geonet.org.nz/fdsnws/dataselect/1/query?network=NZ&sta=WEL&location=*&starttime=2018-05-15T23:45:00&endtime=2018-05-15T23:45:10
+http://service.geonet.org.nz/fdsnws/dataselect/1/query?network=NZ&sta=WEL&location=??&starttime=2018-05-15T23:45:00&endtime=2018-05-15T23:45:10
+http://service.geonet.org.nz/fdsnws/dataselect/1/query?network=NZ&sta=WEL&location=*?&starttime=2018-05-15T23:45:00&endtime=2018-05-15T23:45:10
+http://service.geonet.org.nz/fdsnws/dataselect/1/query?network=NZ&sta=WEL&location=1?&starttime=2018-05-15T23:45:00&endtime=2018-05-15T23:45:10
+http://service.geonet.org.nz/fdsnws/dataselect/1/query?network=NZ&sta=WEL&location=2?&starttime=2018-05-15T23:45:00&endtime=2018-05-15T23:45:10
+http://service.geonet.org.nz/fdsnws/dataselect/1/query?network=NZ&sta=RBCT&location=3?,*&starttime=2018-05-15T23:45:00&endtime=2018-05-15T23:45:10
+
+# Would return part only (99 is non existing  for instance )
+http://service.geonet.org.nz/fdsnws/dataselect/1/query?network=NZ&sta=RBCT&location=30,99&starttime=2018-05-15T23:45:00&endtime=2018-05-15T23:45:10
+http://service.geonet.org.nz/fdsnws/dataselect/1/query?network=NZ&sta=PREZ&location=30,31,32,33,34,35,36,37,38,39&starttime=2018-05-15T23:45:00&endtime=2018-05-15T23:45:10
+
+##### Channel code queries
+# Gets every channels
+http://service.geonet.org.nz/fdsnws/dataselect/1/query?network=NZ&sta=RBCT&starttime=2018-05-15T23:45:00&endtime=2018-05-15T23:45:10
+http://service.geonet.org.nz/fdsnws/dataselect/1/query?network=NZ&sta=RBCT&channel=*&starttime=2018-05-15T23:45:00&endtime=2018-05-15T23:45:10
+http://service.geonet.org.nz/fdsnws/dataselect/1/query?network=NZ&sta=RBCT&channel=???&starttime=2018-05-15T23:45:00&endtime=2018-05-15T23:45:10
+
+# This should fail (channels are 3 ?)
+http://service.geonet.org.nz/fdsnws/dataselect/1/query?network=NZ&sta=RBCT&channel=????&starttime=2018-05-15T23:45:00&endtime=2018-05-15T23:45:10;;204
+
+# Wildcards Combo
+http://service.geonet.org.nz/fdsnws/dataselect/1/query?network=NZ&sta=RBCT&channel=?T?&starttime=2018-05-15T23:45:00&endtime=2018-05-15T23:45:10
+http://service.geonet.org.nz/fdsnws/dataselect/1/query?network=NZ&sta=RBCT&channel=?TZ&starttime=2018-05-15T23:45:00&endtime=2018-05-15T23:45:10
+http://service.geonet.org.nz/fdsnws/dataselect/1/query?network=NZ&sta=RBCT&channel=BT*&starttime=2018-05-15T23:45:00&endtime=2018-05-15T23:45:10
+http://service.geonet.org.nz/fdsnws/dataselect/1/query?network=NZ&sta=RBCT&channel=??F&starttime=2018-05-15T23:45:00&endtime=2018-05-15T23:45:10
+
+# List Channel
+http://service.geonet.org.nz/fdsnws/dataselect/1/query?network=NZ&sta=RBCT&channel=HDF,LTZ,HHZ&starttime=2018-05-15T23:45:00&endtime=2018-05-15T23:45:10
+
+# Fake XXX channel
+http://service.geonet.org.nz/fdsnws/dataselect/1/query?network=NZ&sta=RBCT&channel=HDF,LTZ,XXX&starttime=2018-05-15T23:45:00&endtime=2018-05-15T23:45:10
+# Should retrun nothing
+http://service.geonet.org.nz/fdsnws/dataselect/1/query?network=NZ&sta=WEL&channel=HDF,LTZ,XXX&starttime=2018-05-15T23:45:00&endtime=2018-05-15T23:45:10;;204
+
+##### Station Code queries
+#List1=ABAZ,AKCZ,ALRZ,AMCZ,ANWZ,ARAZ,ARCZ,ARHZ,AWAZ,BHHZ,CAW,CKHZ,CMWZ,CNGZ,CPWZ,CRSZ,DREZ,DUWZ,DVHZ,EDRZ,EPAZ,ETAZ,GCSZ,HBAZ,HLRZ,HOWZ,HRRZ,HSRZ,KAHZ,KARZ,KATZ,KBAZ,KIW,KMRZ,KRHZ,KRVZ,KUTZ,KWHZ,LIRZ,LREZ,MARZ,MBAZ,MCHZ,MHCZ,MHEZ,MHGZ,MKRZ,MOVZ,MRHZ,MRNZ,MSWZ,MTHZ,MTVZ,MTW,MUGZ,MYRZ,NBEZ,NEZ,NGRZ,NGZ
+# list Max 60 stations (Aws quota may fail)
+http://service.geonet.org.nz/fdsnws/dataselect/1/query?network=NZ&sta=${List1}&channel=EHZ&starttime=2018-05-15T23:45:00&endtime=2018-05-15T23:45:10
+#list 60 +1 (should fail)
+#http://service.geonet.org.nz/fdsnws/dataselect/1/query?network=NZ&sta=NMEZ,${List1}&channel=EHZ&starttime=2018-05-15T23:45:00&endtime=2018-05-15T23:45:40;;413
+
+# Not so good a query - return one single answer
+#List2= WEL,WEL,WEL,WEL,WEL,WEL,WEL,WEL
+http://service.geonet.org.nz/fdsnws/dataselect/1/query?network=NZ&sta=${List2}&channel=HHZ&starttime=2018-05-15T23:45:00&endtime=2018-05-15T23:45:10
+
+## Wildcards
+#Ask everything HHZ - may  got nothing (AWS)
+http://service.geonet.org.nz/fdsnws/dataselect/1/query?network=NZ&sta=*&channel=HHZ&starttime=2018-05-15T23:45:00&endtime=2018-05-15T23:45:10
+
+#Only the 3 letters stations 1 channel HHZ may fail upon numbers (AWS quota)
+http://service.geonet.org.nz/fdsnws/dataselect/1/query?network=NZ&sta=???&channel=HHZ&starttime=2018-05-15T23:45:00&endtime=2018-05-15T23:45:10
+
+#Only the 4 letters stations 1 channel EHZ may fail upon numbers (AWS quota)
+http://service.geonet.org.nz/fdsnws/dataselect/1/query?network=NZ&sta=????&channel=EHZ&starttime=2018-05-15T23:45:00&endtime=2018-05-15T23:45:10
+
+#all the I stations
+http://service.geonet.org.nz/fdsnws/dataselect/1/query?network=NZ&sta=I*&starttime=2018-05-15T23:45:00&endtime=2018-05-15T23:45:10
+
+#all the W stations (TODO: reenable this after Fastly configuration changed)
+#http://service.geonet.org.nz/fdsnws/dataselect/1/query?network=NZ&sta=W*&starttime=2018-05-15T23:45:00&endtime=2018-05-15T23:45:10
+
+#all the I 3 letters stations
+http://service.geonet.org.nz/fdsnws/dataselect/1/query?network=NZ&sta=I??&starttime=2018-05-15T23:45:00&endtime=2018-05-15T23:45:10
+
+#all the W 3 letters stations (TODO: reenable this after Fastly configuration changed)
+http://service.geonet.org.nz/fdsnws/dataselect/1/query?network=NZ&sta=W??&starttime=2018-05-15T23:45:00&endtime=2018-05-15T23:45:10

--- a/internal/fdsn/dataselect.go
+++ b/internal/fdsn/dataselect.go
@@ -302,5 +302,13 @@ func GenRegex(input []string, emptyDash bool) ([]string, error) {
 }
 
 func WillBeEmpty(s string) bool {
-	return !(s == `^\s{2}$` || s == "--" || nslcRegPassPattern.MatchString(s))
+	// A query pattern could contains multiple patterns joined by "|", we check one by one
+	for _, t := range strings.Split(s, "|") {
+		// If a query doesn't match any of the patterns below,
+		//   the query will be empty result because it contains unwanted characters.
+		if !(t == `^\s{2}$` || t == "--" || nslcRegPassPattern.MatchString(t)) {
+			return true
+		}
+	}
+	return false
 }

--- a/internal/fdsn/dataselect_test.go
+++ b/internal/fdsn/dataselect_test.go
@@ -180,4 +180,9 @@ func TestWillBeEmpty(t *testing.T) {
 	if shouldT := fdsn.WillBeEmpty(",,"); shouldT != true {
 		t.Error("expected to true got false")
 	}
+	// For GET requests, comma separated parameters will be joined by "|"
+	// The pattern below represents "--,10"
+	if shouldF := fdsn.WillBeEmpty(`^\s{2}$|^10$`); shouldF != false {
+		t.Error("expected to false got true")
+	}
 }


### PR DESCRIPTION
Fixed a parameter error:
A query like `/fdsnws/dataselect/1/query?network=NZ&sta=WEL&location=--,10&starttime=2018-05-15T23:45:00&endtime=2018-05-15T23:45:10` should get at least the location 10 but got nothing.


Also in this PR I implemented the script tool to load URLs specified in  https://github.com/GeoNet/tickets/issues/7524 and test against FDSN services.