### PR TITLE
Update test script to test against any FDSN test service.

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,10 +86,21 @@ Build.sh will automatically re-build these C libraries before building any Go ex
 
 ## Test tool
 
-A test bash script `fdsn-batch-test.sh` (loads URLs from `fdsn-test-urls.txt`) can used to test against both FDSN and FDSN-NRT web service.
+A test bash script `fdsn-batch-test.sh` which loads URLs from `fdsn-test-urls.txt`, can used to test against both FDSN and FDSN-NRT web service.
+
+### fdsn-batch-test.sh
+
+```
+./fdsn-batch-test.sh {optional_test_fdsn_service}
+```
+When `{optional_test_fdsn_service}` is omitted, the script will test against `service.geonet.org.nz` and `service-nrt.geonet.org.nz`. When `{optional_test_fdsn_service}` is present, the script tests against that service with the same URLs defined in the txt file.
+
+### fdsn-test-urls.txt
+
+Update `fdsn-test-urls.txt` to change the URLs to test.
 
 For tests expecting http response status code other than 200, append `;;{expected_http_code}` after the URL, for example:
 ```
 http://service.geonet.org.nz/fdsnws/dataselect/1/query?network=NZ&sta=RBCT&channel=????&starttime=2018-05-15T23:45:00&endtime=2018-05-15T23:45:10;;204
 ```
-The test script will test the URL to see if the responsed http status is 204.
+The above `;;204` suffix makes test script to check whether the responsed http status is 204.

--- a/fdsn-batch-test.sh
+++ b/fdsn-batch-test.sh
@@ -4,9 +4,13 @@ list_placeholder1="\${List1}"
 list_placeholder2="\${List2}"
 list1="ABAZ,AKCZ,ALRZ,AMCZ,ANWZ,ARAZ,ARCZ,ARHZ,AWAZ,BHHZ,CAW,CKHZ,CMWZ,CNGZ,CPWZ,CRSZ,DREZ,DUWZ,DVHZ,EDRZ,EPAZ,ETAZ,GCSZ,HBAZ,HLRZ,HOWZ,HRRZ,HSRZ,KAHZ,KARZ,KATZ,KBAZ,KIW,KMRZ,KRHZ,KRVZ,KUTZ,KWHZ,LIRZ,LREZ,MARZ,MBAZ,MCHZ,MHCZ,MHEZ,MHGZ,MKRZ,MOVZ,MRHZ,MRNZ,MSWZ,MTHZ,MTVZ,MTW,MUGZ,MYRZ,NBEZ,NEZ,NGRZ,NGZ"
 list2="WEL,WEL,WEL,WEL,WEL,WEL,WEL,WEL"
+
+if [ -z "$1"]; then
 # firstly run through the test (should be against service.geonet.org.nz)
+linenum=0
 while IFS= read -r line
 do
+  linenum=$((linenum + 1))
   if ! [[ $line = \#* ]] && ! [[ -z $line ]] ; then
     tk=(${line//;;/ })
     if (( ${#tk[*]} > 1 )) ; then
@@ -19,21 +23,35 @@ do
     echo "expecting $res for $line"
     r=$(curl -f --write-out %{http_code} -s --output /dev/null "$line")
     if ! [ $? -eq 0 ] || ! [ $r -eq ${res} ] ; then
-        echo "Error $line expect $res got result $r"
+        echo "L$linenum: Error $line expect $res got result $r"
         exit 1
     fi
   fi
 done < "$input"
+fi
 
 # now do nrt
 service="service.geonet.org.nz"
-service_nrt="service-nrt.geonet.org.nz"
-sample_date="2018-05-15"
-nrt_date=$(date -v-1d +'%Y-%m-%d') # 1 day ago
-echo "NRT test date: $nrt_date"
 
+if [ -z "$1"]; then
+service_nrt="service-nrt.geonet.org.nz"
+else
+service_nrt="$1"
+fi 
+sample_date="2018-05-15"
+sample_tstart="23:45:00"
+sample_tend="23:45:10"
+# Note1 : this date/time string replacing won't work when start/end window is crossing midnight
+# Note2 : For OSX replace `-d "20 minutes ago"` with `-v-20M`, and -v-15M for end time.
+nrt_date=$(TZ="GMT0" date -d "20 minutes ago" +'%Y-%m-%d')
+nrt_tstart=$(TZ="GMT0" date -d "20 minutes ago" +'%H:%M:%S') #start: 20 min age
+nrt_tend=$(TZ="GMT0" date -d "15 minutes ago" +'%H:%M:%S') #end: 15 min ago
+echo "NRT test date: $nrt_date $nrt_tstart to $nrt_tend"
+
+linenum=0
 while IFS= read -r line
 do
+  linenum=$((linenum + 1))
   if ! [[ $line = \#* ]] && ! [[ -z $line ]] ; then
     tk=(${line//;;/ })
     if (( ${#tk[*]} > 1 )) ; then
@@ -44,11 +62,13 @@ do
     line=${tk[0]/$list_placeholder1/$list1}  # replace stations
     line=${line/$list_placeholder2/$list2}  # replace stations
     line=${line/$service/$service_nrt}  # replace server name to nrt
-    line=${line//$sample_date/$nrt_date} # replace date to 1 day ago
+    line=${line//$sample_date/$nrt_date} # replace date today
+    line=${line//$sample_tstart/$nrt_tstart} # replace starttime to 20 mins ago
+    line=${line//$sample_tend/$nrt_tend} # replace endtime to 15 mins ago
     echo "$line"
     r=$(curl -f --write-out %{http_code} -s --output /dev/null "$line")
     if ! [ $? -eq 0 ] || ! [ $r -eq ${res} ] ; then
-        echo "Error $line expect $res got result $r"
+        echo "L$linenum: Error $line expect $res got result $r"
         exit 1
     fi
   fi

--- a/fdsn-test-urls.txt
+++ b/fdsn-test-urls.txt
@@ -7,8 +7,8 @@
 http://service.geonet.org.nz/fdsnws/dataselect/1/query?network=NZ&sta=WEL&location=00,10,11,20,21&starttime=2018-05-15T23:45:00&endtime=2018-05-15T23:45:10
 http://service.geonet.org.nz/fdsnws/dataselect/1/query?network=NZ&sta=WEL&location=00,10,11,20,21&starttime=2018-05-15T23:45:00&endtime=2018-05-15T23:45:10
 # TODO: add "--" to the location list for the 2 tests above after fix deployed.
-http://service.geonet.org.nz/fdsnws/dataselect/1/query?network=NZ&sta=WEL&location=00,10,11,20,21,22&starttime=2018-05-15T23:45:00&endtime=2018-05-15T23:45:10
-http://service.geonet.org.nz/fdsnws/dataselect/1/query?network=NZ&sta=RBCT&location=30,40&starttime=2018-05-15T23:45:00&endtime=2018-05-15T23:45:10
+http://service.geonet.org.nz/fdsnws/dataselect/1/query?network=NZ&sta=WEL&location=--,00,10,11,20,21,22&starttime=2018-05-15T23:45:00&endtime=2018-05-15T23:45:10
+http://service.geonet.org.nz/fdsnws/dataselect/1/query?network=NZ&sta=RBCT&location=--,30,40&starttime=2018-05-15T23:45:00&endtime=2018-05-15T23:45:10
 
 # Wilcard test
 http://service.geonet.org.nz/fdsnws/dataselect/1/query?network=NZ&sta=RBCT&location=3?,4?&starttime=2018-05-15T23:45:00&endtime=2018-05-15T23:45:10
@@ -71,7 +71,7 @@ http://service.geonet.org.nz/fdsnws/dataselect/1/query?network=NZ&sta=????&chann
 http://service.geonet.org.nz/fdsnws/dataselect/1/query?network=NZ&sta=I*&starttime=2018-05-15T23:45:00&endtime=2018-05-15T23:45:10
 
 #all the W stations (TODO: reenable this after Fastly configuration changed)
-#http://service.geonet.org.nz/fdsnws/dataselect/1/query?network=NZ&sta=W*&starttime=2018-05-15T23:45:00&endtime=2018-05-15T23:45:10
+http://service.geonet.org.nz/fdsnws/dataselect/1/query?network=NZ&sta=W*&starttime=2018-05-15T23:45:00&endtime=2018-05-15T23:45:10
 
 #all the I 3 letters stations
 http://service.geonet.org.nz/fdsnws/dataselect/1/query?network=NZ&sta=I??&starttime=2018-05-15T23:45:00&endtime=2018-05-15T23:45:10


### PR DESCRIPTION
Made some change to test scripts to make it better and able to test staging servers.
Enabled the "TODO" urls (will fail against existing deployment of FDSN and FDSN-NRT, should pass after the service updated).