### PR TITLE
Fix docker build app name issue so metrics in Datadog got their real app name.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,4 @@ cmd/slink-strong-db/slink-strong-db
 cmd/s3-notify/s3-notify
 *.o
 *.a
+Dockerfile

--- a/Dockerfile_template
+++ b/Dockerfile_template
@@ -46,10 +46,10 @@ ARG BUILD
 ENV TZ Pacific/Auckland
 ENV BUILD_BIN=${BUILD}
 # We have to make our binary have a fixed name, otherwise, we cannot run it without a shell
-COPY --from=builder /repo/gobin/${BUILD} /app
+COPY --from=builder /repo/gobin/${BUILD} /${BUILD}
 # Copy the assets
 ARG ASSET_DIR
 COPY ${ASSET_DIR} /assets
 ARG RUN_USER=nobody
 USER ${RUN_USER}
-CMD ["/app"]
+# Requires a CMD ["/${BUILD}"] appended by build.sh

--- a/build.sh
+++ b/build.sh
@@ -38,6 +38,9 @@ for i in "$@"; do
     ASSET_DIR="./cmd/${i}/assets"
   fi
 
+  cat Dockerfile_template > Dockerfile
+  echo "CMD [\"/${i}\"]" >> Dockerfile
+
   docker build \
     --build-arg=BUILD="$i" \
     --build-arg=RUNNER_IMAGE="$RUNNER_IMAGE" \


### PR DESCRIPTION
As title.

Previous docker improvement made all app running in container having `app` as the executable name, this unable to distinguish the real application in Datadog metrics.