### PR TITLE
Log POST body when needed

### DIFF
--- a/cmd/fdsn-ws/env.list
+++ b/cmd/fdsn-ws/env.list
@@ -25,4 +25,7 @@ STATION_XML_BUCKET=geonet-static2
 STATION_XML_META_KEY=fdsn-station-test.xml
 STATION_RELOAD_INTERVAL=300
 
+# Log POST request body, 'true' or 'false'
+LOG_EXTRA=
+
 DDOG_API_KEY=

--- a/cmd/fdsn-ws/fdsn_dataselect.go
+++ b/cmd/fdsn-ws/fdsn_dataselect.go
@@ -4,14 +4,6 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
-	"github.com/GeoNet/fdsn/internal/fdsn"
-	"github.com/GeoNet/kit/metrics"
-	"github.com/GeoNet/kit/mseed"
-	"github.com/GeoNet/kit/weft"
-	"github.com/aws/aws-sdk-go/aws"
-	"github.com/aws/aws-sdk-go/aws/client"
-	"github.com/aws/aws-sdk-go/aws/session"
-	"github.com/aws/aws-sdk-go/service/s3"
 	"io"
 	"io/ioutil"
 	"log"
@@ -22,6 +14,15 @@ import (
 	"strings"
 	"text/template"
 	"time"
+
+	"github.com/GeoNet/fdsn/internal/fdsn"
+	"github.com/GeoNet/kit/metrics"
+	"github.com/GeoNet/kit/mseed"
+	"github.com/GeoNet/kit/weft"
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/client"
+	"github.com/aws/aws-sdk-go/aws/session"
+	"github.com/aws/aws-sdk-go/service/s3"
 )
 
 const (
@@ -169,6 +170,11 @@ func fdsnDataselectV1Handler(r *http.Request, w http.ResponseWriter) (int64, err
 	if len(params) > MAX_QUERIES {
 		return 0, weft.StatusError{Code: http.StatusRequestEntityTooLarge,
 			Err: fmt.Errorf("number of queries in the POST request: %d exceeded the limit: %d", len(params), MAX_QUERIES)}
+	}
+
+	//Log extra information about POST request if needed
+	if r.Method == "POST" && LOG_EXTRA {
+		log.Printf("About to execute the following query params: %+v\n", params)
 	}
 
 	// search the holdings DB for the files to fetch from S3.

--- a/cmd/fdsn-ws/server.go
+++ b/cmd/fdsn-ws/server.go
@@ -2,19 +2,21 @@ package main
 
 import (
 	"database/sql"
-	"github.com/GeoNet/kit/cfg"
-	"github.com/gorilla/schema"
-	_ "github.com/lib/pq"
 	"log"
 	"net/http"
 	"os"
 	"time"
+
+	"github.com/GeoNet/kit/cfg"
+	"github.com/gorilla/schema"
+	_ "github.com/lib/pq"
 )
 
 var (
 	db           *sql.DB
 	decoder      = schema.NewDecoder() // decoder for URL queries.
 	S3_BUCKET    string                // the S3 bucket storing the miniseed files used by dataselect
+	LOG_EXTRA    bool                  // Whether POST body is logged.
 	zeroDateTime time.Time
 )
 
@@ -26,6 +28,11 @@ func main() {
 	var err error
 	if S3_BUCKET = os.Getenv("S3_BUCKET"); S3_BUCKET == "" {
 		log.Fatal("ERROR: S3_BUCKET environment variable is not set")
+	}
+
+	LOG_EXTRA = false
+	if log_extra := os.Getenv("LOG_EXTRA"); log_extra == "true" {
+		LOG_EXTRA = true
 	}
 
 	p, err := cfg.PostgresEnv()


### PR DESCRIPTION
Today there have been some POST requests to FDSN that have resulted in out of memory issues. At the moment we can't see what parameters are being provided in those POST requests, so this just logs them just before they're executed.