### PR TITLE
Fix query cross 180 meridian issue for event service.

### DIFF
--- a/cmd/fdsn-ws/fdsn_event.go
+++ b/cmd/fdsn-ws/fdsn_event.go
@@ -385,13 +385,13 @@ func (e *fdsnEventV1) filter() (q string, args []interface{}) {
 	}
 
 	if e.MaxRadius != 180.0 {
-		q = fmt.Sprintf("%s ST_Distance(origin_geom::GEOMETRY, ST_SetSRID(ST_Makepoint($%d, $%d), 4326)) <= $%d AND", q, i, i+1, i+2)
+		q = fmt.Sprintf("%s ST_Distance(ST_ShiftLongitude(origin_geom::GEOMETRY), ST_ShiftLongitude(ST_SetSRID(ST_Makepoint($%d, $%d), 4326))) <= $%d AND", q, i, i+1, i+2)
 		args = append(args, e.Longitude, e.Latitude, e.MaxRadius)
 		i += 3
 	}
 
 	if e.MinRadius != 0.0 {
-		q = fmt.Sprintf("%s ST_Distance(origin_geom::GEOMETRY, ST_SetSRID(ST_Makepoint($%d, $%d), 4326)) >= $%d AND", q, i, i+1, i+2)
+		q = fmt.Sprintf("%s ST_Distance(ST_ShiftLongitude(origin_geom::GEOMETRY), ST_ShiftLongitude(ST_SetSRID(ST_Makepoint($%d, $%d), 4326))) >= $%d AND", q, i, i+1, i+2)
 		args = append(args, e.Longitude, e.Latitude, e.MinRadius)
 	}
 

--- a/cmd/fdsn-ws/fdsn_event_test.go
+++ b/cmd/fdsn-ws/fdsn_event_test.go
@@ -365,6 +365,7 @@ func TestLongitudeWrap180(t *testing.T) {
 		t.Errorf("expected 1 records got %d\n", c)
 	}
 
+	v = url.Values{}
 	v.Set("minlon", "176")
 	v.Set("maxlon", "-176")
 	e, err = parseEventV1(v)
@@ -381,7 +382,7 @@ func TestLongitudeWrap180(t *testing.T) {
 		t.Errorf("expected 2 records got %d\n", c)
 	}
 
-	v.Del("minlon")
+	v = url.Values{}
 	v.Set("maxlon", "-177.0")
 	e, err = parseEventV1(v)
 	if err != nil {
@@ -397,4 +398,23 @@ func TestLongitudeWrap180(t *testing.T) {
 		t.Errorf("expected 1 records got %d\n", c)
 	}
 
+	v = url.Values{}
+	v.Set("lon", "179.4")
+	v.Set("lat", "-40.57806609")
+	v.Set("maxradius", "5")
+	// 2 records, 176.3257242 and another at -176.3257242, distances are 4.27 and 3.07
+	// if the query can cross 180 then we'll get 2 records
+	e, err = parseEventV1(v)
+	if err != nil {
+		t.Error(err)
+	}
+
+	c, err = e.count()
+	if err != nil {
+		t.Error(err)
+	}
+
+	if c != 2 {
+		t.Errorf("expected 2 records got %d\n", c)
+	}
 }


### PR DESCRIPTION
As stated in https://github.com/GeoNet/fdsn/issues/212.

Below are results to query against 2 points on the different side of meridian.

The existing query
```
fdsn=> select ST_X(origin_geom::GEOMETRY),ST_Y(origin_geom::GEOMETRY), ST_Distance(origin_geom::GEOMETRY, ST_SetSRID(ST_Makepoint(-179.40,-40.57), 4326)) from fdsn.event;
     st_x     |     st_y     |    st_distance
--------------+--------------+--------------------
  176.3257242 | -40.57806609 |  355.7257242914494
 -176.3257242 | -40.57806609 | 3.0742863816296597
(2 rows)
```
As you can see the above results, the distance between -179.40 to 176.32 is 355.

Below is the result of updated SQL query:
```
fdsn=> select ST_X(origin_geom::GEOMETRY),ST_Y(origin_geom::GEOMETRY), ST_Distance(ST_ShiftLongitude(origin_geom::GEOMETRY), ST_ShiftLongitude(ST_SetSRID(ST_Makepoint(-179.40,-40.57), 4326))) from fdsn.event;
     st_x     |     st_y     |    st_distance
--------------+--------------+--------------------
  176.3257242 | -40.57806609 | 4.2742834108507015
 -176.3257242 | -40.57806609 | 3.0742863816296597
(2 rows)
```
which has the correct results.