### PR TITLE
Add EventType column for v1.2 in /event service.

### DIFF
--- a/cmd/fdsn-ws/assets/tmpl/fdsn-ws-event.wadl
+++ b/cmd/fdsn-ws/assets/tmpl/fdsn-ws-event.wadl
@@ -1,6 +1,7 @@
 {{define "body" -}}
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<application xmlns="http://wadl.dev.java.net/2009/02">
+<application xmlns="http://wadl.dev.java.net/2009/02"
+		xmlns:xsd="http://www.w3.org/2001/XMLSchema">
     <doc title="FDSN event web service 1.0"/>
     <resources base="https://{{.}}/fdsnws/event/1/">
 
@@ -8,65 +9,65 @@
             <method id="query" name="GET">
                 <request>
                     <doc xml:lang="english" title="the response size is limited to 10,000 events."/>
-                    <param xmlns:xs="http://www.w3.org/2001/XMLSchema" name="starttime" style="query" type="xs:date">
+                    <param name="starttime" style="query" type="xs:date">
                         <doc xml:lang="english" title="limit to events occurring on or after the specified start time">
                             Examples: starttime=2012-11-29 or 2012-11-29T00:00:00 or 2012-11-29T00:00:00.000
                         </doc>
                     </param>
-                    <param xmlns:xs="http://www.w3.org/2001/XMLSchema" name="endtime" style="query" type="xs:date">
+                    <param name="endtime" style="query" type="xs:date">
                         <doc xml:lang="english" title="limit to events occurring on or before the specified end time"/>
                     </param>
-                    <param xmlns:xs="http://www.w3.org/2001/XMLSchema" name="minlatitude" style="query" type="xs:double"
+                    <param name="minlatitude" style="query" type="xs:double"
                            default="-90.0">
                         <doc xml:lang="english" title="southern boundary"/>
                     </param>
-                    <param xmlns:xs="http://www.w3.org/2001/XMLSchema" name="maxlatitude" style="query" type="xs:double"
+                    <param name="maxlatitude" style="query" type="xs:double"
                            default="90.0">
                         <doc xml:lang="english" title="northern boundary"/>
                     </param>
-                    <param xmlns:xs="http://www.w3.org/2001/XMLSchema" name="minlongitude" style="query"
+                    <param name="minlongitude" style="query"
                            type="xs:double" default="-180.0">
                         <doc xml:lang="english" title="western boundary"/>
                     </param>
-                    <param xmlns:xs="http://www.w3.org/2001/XMLSchema" name="maxlongitude" style="query"
+                    <param name="maxlongitude" style="query"
                            type="xs:double" default="180.0">
                         <doc xml:lang="english" title="eastern boundary"/>
                     </param>
-                    <param xmlns:xs="http://www.w3.org/2001/XMLSchema" name="minmagnitude" style="query"
+                    <param name="minmagnitude" style="query"
                            type="xs:double">
                         <doc xml:lang="english"
                              title="Limit to events with a magnitude larger than or equal to the specified minimum"/>
                     </param>
-                    <param xmlns:xs="http://www.w3.org/2001/XMLSchema" name="maxmagnitude" style="query"
+                    <param name="maxmagnitude" style="query"
                            type="xs:double">
                         <doc xml:lang="english"
                              title="Limit to events with a magnitude smaller than or equal to the specified maximum"/>
                     </param>
-                    <param xmlns:xs="http://www.w3.org/2001/XMLSchema" name="maxdepth" style="query" type="xs:double">
+                    <param name="maxdepth" style="query" type="xs:double">
                         <doc xml:lang="english"
                              title="Limit to events with depths equal to or less than the specified depth"/>
                     </param>
-                    <param xmlns:xs="http://www.w3.org/2001/XMLSchema" name="mindepth" style="query" type="xs:double">
+                    <param name="mindepth" style="query" type="xs:double">
                         <doc xml:lang="english"
                              title="Limit to events with depths equal to or greater than the specified depth"/>
                     </param>
-                    <param xmlns:xs="http://www.w3.org/2001/XMLSchema" name="latitude" style="query" type="xs:double" default="0.0">
+                    <param name="latitude" style="query" type="xs:double" default="0.0">
                         <doc xml:lang="english"
                             title="Specify the central latitude point for a radial search"/>
                     </param>
-                    <param xmlns:xs="http://www.w3.org/2001/XMLSchema" name="longitude" style="query" type="xs:double" default="0.0">
+                    <param name="longitude" style="query" type="xs:double" default="0.0">
                         <doc xml:lang="english"
                             title="Specify the central longitude point for a radial search"/>
                     </param>
-                    <param xmlns:xs="http://www.w3.org/2001/XMLSchema" name="maxradius" style="query" type="xs:double" default="180.0">
+                    <param name="maxradius" style="query" type="xs:double" default="180.0">
                         <doc xml:lang="english"
                             title="Specify maximum distance from the geographic point defined by latitude and longitude"/>
                     </param>
-                    <param xmlns:xs="http://www.w3.org/2001/XMLSchema" name="minradius" style="query" type="xs:double" default="0.0">
+                    <param name="minradius" style="query" type="xs:double" default="0.0">
                         <doc xml:lang="english"
                             title="Specify minimum distance from the geographic point defined by latitude and longitude"/>
                     </param>
-                    <param xmlns:xs="http://www.w3.org/2001/XMLSchema" name="orderby" style="query" type="xs:string"
+                    <param name="orderby" style="query" type="xs:string"
                            default="time">
                         <doc xml:lang="english" title="Specify the ordering of the returned results"/>
                         <option value="time">
@@ -82,22 +83,26 @@
                             <doc xml:lang="english" title="Sort by magnitude, ascending"/>
                         </option>
                     </param>
-                    <param xmlns:xs="http://www.w3.org/2001/XMLSchema" name="eventid" style="query" type="xs:string">
+                    <param name="eventid" style="query" type="xs:string">
                         <doc xml:lang="english"
                              title="Retrieve an event based on the unique ID numbers assigned by the IRIS DMC"/>
                     </param>
-                    <param xmlns:xs="http://www.w3.org/2001/XMLSchema" name="format" style="query" type="xs:string" default="xml">
+                    <param name="format" style="query" type="xs:string" default="xml">
                         <doc xml:lang="english" title="Specify output format. This is an IRIS extension to the FDSN specification"/>
                         <option value="xml" mediaType="application/xml"/>
                         <option value="text" mediaType="text/plain"/>
                     </param>
-                    <param xmlns:xs="http://www.w3.org/2001/XMLSchema" name="nodata" style="query" type="xs:int" default="204">
+                    <param name="nodata" style="query" type="xs:int" default="204">
                         <doc xml:lang="english" title="Specify which HTML Status code is returned when no data is found."/>
                         <option value="204"/>
                         <option value="404"/>
                     </param>
-                    <param xmlns:xs="http://www.w3.org/2001/XMLSchema" name="updatedafter" style="query" type="xs:date">
+                    <param name="updatedafter" style="query" type="xs:date">
                         <doc xml:lang="english" title="Limit to events updated after the specified time"/>
+                    </param>
+					<param name="eventtype" style="query" type="xs:string" default="*">
+						<doc xml:lang="english" title="Limit to events with a specified eventType. The parameter value can be a single item, a comma-separated list of items, or the asterisk wildcard. Allowed values are
+from the QuakeML 1.2 EventType enumeration."/>
                     </param>
                 </request>
                 <response>

--- a/cmd/fdsn-ws/assets/tmpl/fdsn-ws-station.wadl
+++ b/cmd/fdsn-ws/assets/tmpl/fdsn-ws-station.wadl
@@ -1,4 +1,5 @@
 {{define "body" -}}
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <application xmlns="http://wadl.dev.java.net/2009/02"
 		xmlns:xsd="http://www.w3.org/2001/XMLSchema">
 	<resources base="http://{{.}}/fdsnws/1/station">
@@ -29,7 +30,6 @@
 						<option value="channel"/>
 						<option value="response"/>
 					</param>
-					<param name="includerestricted" style="query" type="xsd:boolean" default="false"/>
 					<param name="nodata" style="query" type="xsd:int" default="204">
 						<option value="204"/>
 						<option value="404"/>
@@ -39,7 +39,6 @@
 						<option value="text"/>
 					</param>
 
-					<!-- additional, non standard parameters -->
 					<param name="formatted" style="query" type="xsd:boolean" default="false">
 						<doc>
 							Controls formatted (pretty print) output.
@@ -51,9 +50,6 @@
                         <option value="204"/>
                         <option value="404"/>
                     </param>
-
-					<!-- not implemented -->
-					<!--param name="updateafter" style="query" type="xsd:dateTime"/-->
 				</request>
 				<response status="200">
 					<representation mediaType="application/xml"/>

--- a/cmd/fdsn-ws/fdsn_event.go
+++ b/cmd/fdsn-ws/fdsn_event.go
@@ -79,9 +79,19 @@ var eventNotSupported = map[string]bool{
 }
 
 // copied from p.17 of FDSN-WS-Specifications-1.2.pdf
-const EVENT_TYPES = `not existing, not reported, earthquake, anthropogenic event, collapse, cavity collapse, mine collapse, building collapse, explosion, accidental explosion, chemical explosion, controlled explosion, experimental explosion, industrial explosion, mining explosion, quarry blast, road cut, blasting levee, nuclear explosion, induced or triggered event, rock burst, reservoir loading, fluid injection, fluid extraction, crash, plane crash, train crash, boat crash, other event, atmospheric event, sonic boom, sonic blast, acoustic noise, thunder, avalanche, snow avalanche, debris avalanche, hydroacoustic event, ice quake, slide, landslide, rockslide, meteorite, volcanic eruption`
+const EVENT_TYPES = `not existing, not reported, earthquake, anthropogenic event, collapse,
+cavity collapse, mine collapse, building collapse, explosion, accidental explosion, chemical explosion,
+controlled explosion, experimental explosion, industrial explosion, mining explosion, quarry blast,
+road cut, blasting levee, nuclear explosion, induced or triggered event, rock burst, reservoir loading,
+fluid injection, fluid extraction, crash, plane crash, train crash, boat crash, other event,
+atmospheric event, sonic boom, sonic blast, acoustic noise, thunder, avalanche, snow avalanche,
+debris avalanche, hydroacoustic event, ice quake, slide, landslide, rockslide, meteorite, volcanic eruption`
 
-var validEventTypes = strings.Split(strings.ReplaceAll(EVENT_TYPES, ", ", ","), ",") // remove spaces after comma
+var validEventTypes = strings.Split(
+	strings.ReplaceAll(
+		strings.ReplaceAll(EVENT_TYPES, "\n", ""),
+		", ", ","),
+	",") // remove spaces after comma
 
 func init() {
 	var err error
@@ -258,12 +268,12 @@ func parseEventV1(v url.Values) (fdsnEventV1, error) {
 			}
 		}
 
-		if qp != "" {
-			e.eventTypeStr = strings.TrimSuffix(qp, ",") // remove the unnecessary last comma
-		} else {
+		if qp == "" {
 			err = fmt.Errorf("invalid value for eventtype: %s", e.EventType)
 			return e, err
 		}
+
+		e.eventTypeStr = strings.TrimSuffix(qp, ",") // remove the unnecessary last comma
 	} else {
 		// default value, no filtering
 		e.eventTypeStr = ""

--- a/cmd/fdsn-ws/fdsn_event_test.go
+++ b/cmd/fdsn-ws/fdsn_event_test.go
@@ -431,7 +431,7 @@ func TestEventTypes(t *testing.T) {
 		{"z*", true, nil}, // no such match, expected value doesn't matter
 		{"experimental explosion", false, []interface{}{"experimental explosion"}},
 		{"e*,a*", false, []interface{}{"earthquake", "anthropogenic event", "explosion", "accidental explosion", "experimental explosion", "atmospheric event", "acoustic noise", "avalanche"}},
-		{"", false, []interface{}{""}},
+		{"unknown", false, []interface{}{""}}, // specify "unknown" means query for empty value
 	}
 	for _, c := range queryCases {
 		v := url.Values{}

--- a/cmd/fdsn-ws/fdsn_event_test.go
+++ b/cmd/fdsn-ws/fdsn_event_test.go
@@ -431,7 +431,7 @@ func TestEventTypes(t *testing.T) {
 		{"z*", true, nil}, // no such match, expected value doesn't matter
 		{"experimental explosion", false, []interface{}{"experimental explosion"}},
 		{"e*,a*", false, []interface{}{"earthquake", "anthropogenic event", "explosion", "accidental explosion", "experimental explosion", "atmospheric event", "acoustic noise", "avalanche"}},
-		// TODO: how do query for "unset eventtype"? The spec list all allowed values and empty is not in the list.
+		{"", false, []interface{}{""}},
 	}
 	for _, c := range queryCases {
 		v := url.Values{}

--- a/cmd/fdsn-ws/fdsn_event_test.go
+++ b/cmd/fdsn-ws/fdsn_event_test.go
@@ -424,13 +424,13 @@ func TestEventTypes(t *testing.T) {
 	queryCases := []struct {
 		query     string
 		shouldErr bool
-		expected  string
+		expected  []interface{}
 	}{
-		{"earthquake", false, "'earthquake'"},
-		{"e*", false, "'earthquake','explosion','experimental explosion'"},
-		{"z*", true, ""}, // no such match
-		{"experimental explosion", false, "'experimental explosion'"},
-		{"e*,a*", false, "'earthquake','anthropogenic event','explosion','accidental explosion','experimental explosion','atmospheric event','acoustic noise','avalanche'"},
+		{"earthquake", false, []interface{}{"earthquake"}},
+		{"e*", false, []interface{}{"earthquake", "explosion", "experimental explosion"}},
+		{"z*", true, nil}, // no such match, expected value doesn't matter
+		{"experimental explosion", false, []interface{}{"experimental explosion"}},
+		{"e*,a*", false, []interface{}{"earthquake", "anthropogenic event", "explosion", "accidental explosion", "experimental explosion", "atmospheric event", "acoustic noise", "avalanche"}},
 		// TODO: how do query for "unset eventtype"? The spec list all allowed values and empty is not in the list.
 	}
 	for _, c := range queryCases {
@@ -445,8 +445,13 @@ func TestEventTypes(t *testing.T) {
 			t.Errorf("expected to error but passed for %s", c.query)
 			continue
 		}
-		if e.eventTypeStr != c.expected {
-			t.Errorf("expected %s got %s", c.expected, e.eventTypeStr)
+		if len(e.eventTypeSlice) != len(c.expected) {
+			t.Errorf("expected %v got %v", c.expected, e.eventTypeSlice)
+		}
+		for i, v := range c.expected {
+			if e.eventTypeSlice[i] != v {
+				t.Errorf("expected %s got %s", v, e.eventTypeSlice[i])
+			}
 		}
 	}
 

--- a/cmd/fdsn-ws/routes.go
+++ b/cmd/fdsn-ws/routes.go
@@ -92,7 +92,7 @@ func fdsnErrorHandler(err error, h http.Header, b *bytes.Buffer) error {
 		h.Set("Content-Type", "text/plain; charset=utf-8")
 
 		switch e.Code {
-		case http.StatusNoContent, http.StatusNotFound: // NOTE: thought NoContent is not an error but we handled here
+		case http.StatusNoContent, http.StatusNotFound: // NOTE: though NoContent is not an error but we handled here
 			h.Set("Surrogate-Control", "max-age=10")
 		case http.StatusBadRequest:
 			h.Set("Surrogate-Control", "max-age=86400")

--- a/cmd/fdsn-ws/server.go
+++ b/cmd/fdsn-ws/server.go
@@ -20,6 +20,10 @@ var (
 	zeroDateTime time.Time
 )
 
+var stationVersion = "1.1"
+var eventVersion = "1.2"
+var dataselectVersion = "1.1"
+
 func init() {
 	zeroDateTime = time.Date(1, 1, 1, 0, 0, 0, 0, time.UTC)
 }

--- a/internal/fdsn/dataselect_test.go
+++ b/internal/fdsn/dataselect_test.go
@@ -154,7 +154,7 @@ func TestGenRegex(t *testing.T) {
 
 	_, err = fdsn.GenRegex([]string{"10,20"}, false, false)
 	if err != nil {
-		t.Error(fmt.Sprintf("expect to pass but rejected."))
+		t.Error("expect to pass but rejected.")
 	}
 
 	_, err = fdsn.GenRegex([]string{"10 20"}, false, true) // allows space

--- a/internal/fdsn/dataselect_test.go
+++ b/internal/fdsn/dataselect_test.go
@@ -104,7 +104,7 @@ func TestParseGet(t *testing.T) {
 
 func TestGenRegex(t *testing.T) {
 	// normal case
-	r, err := fdsn.GenRegex([]string{"ABA0"}, false)
+	r, err := fdsn.GenRegex([]string{"ABA0"}, false, false)
 	if err != nil {
 		t.Error(err)
 	}
@@ -113,7 +113,7 @@ func TestGenRegex(t *testing.T) {
 	}
 
 	// "--" empty location
-	r, err = fdsn.GenRegex([]string{"--"}, true)
+	r, err = fdsn.GenRegex([]string{"--"}, true, false)
 	if err != nil {
 		t.Error(err)
 	}
@@ -122,7 +122,7 @@ func TestGenRegex(t *testing.T) {
 	}
 
 	// "?" and "*" special
-	r, err = fdsn.GenRegex([]string{"A?Z*"}, false)
+	r, err = fdsn.GenRegex([]string{"A?Z*"}, false, false)
 	if err != nil {
 		t.Error(err)
 	}
@@ -131,28 +131,33 @@ func TestGenRegex(t *testing.T) {
 	}
 
 	// "--" (exactly 2 hyphens) means empty in FDSN
-	_, err = fdsn.GenRegex([]string{"--"}, false)
+	_, err = fdsn.GenRegex([]string{"--"}, false, false)
 	if err != nil {
 		t.Error("expect to passed but rejected")
 	}
 
-	_, err = fdsn.GenRegex([]string{"---"}, false)
+	_, err = fdsn.GenRegex([]string{"---"}, false, false)
 	if err == nil {
 		t.Error("expect to rejected but passed")
 	}
 
 	// block all other chars, including valid regex since we're not supporting regex
-	_, err = fdsn.GenRegex([]string{"*\\^{]"}, false)
+	_, err = fdsn.GenRegex([]string{"*\\^{]"}, false, false)
 	if err == nil {
 		t.Error("expect to rejected but passed.")
 	}
 
-	_, err = fdsn.GenRegex([]string{"[E,H]H?"}, false)
+	_, err = fdsn.GenRegex([]string{"[E,H]H?"}, false, false)
 	if err == nil {
 		t.Error("expect to rejected but passed.")
 	}
 
-	_, err = fdsn.GenRegex([]string{"10,20"}, false)
+	_, err = fdsn.GenRegex([]string{"10,20"}, false, false)
+	if err != nil {
+		t.Error(fmt.Sprintf("expect to pass but rejected."))
+	}
+
+	_, err = fdsn.GenRegex([]string{"10 20"}, false, true) // allows space
 	if err != nil {
 		t.Error("expect to pass but rejected.")
 	}


### PR DESCRIPTION
Regarding to https://github.com/GeoNet/tickets/issues/10574.
Added `EventType` column for compliance with FDSN event service v1.2.

The stations service has some unsupported query parameters like event service, but I'm not changing it to use a generalised error message because some services really using that query parameter - though the value is always the default value and requires no operation for existing query.