### PR TITLE
Fix station filter logic for nodes having no children.

### DIFF
--- a/cmd/fdsn-ws/fdsn_station_test.go
+++ b/cmd/fdsn-ws/fdsn_station_test.go
@@ -2,10 +2,11 @@ package main
 
 import (
 	"encoding/xml"
-	wt "github.com/GeoNet/kit/weft/wefttest"
 	"net/url"
 	"strings"
 	"testing"
+
+	wt "github.com/GeoNet/kit/weft/wefttest"
 )
 
 // NOTE: To run the test, please export :


### PR DESCRIPTION
As requested in https://github.com/GeoNet/tickets/issues/12671.
Also, text output will be in sync with XML output https://github.com/GeoNet/help/issues/103.

Previously we deliberately make it not exists, so the fix is remove those extras.