### PR TITLE
Fix station service text output bug.

### DIFF
--- a/cmd/fdsn-ws/fdsn_station.go
+++ b/cmd/fdsn-ws/fdsn_station.go
@@ -591,7 +591,7 @@ func (r *FDSNStationXML) marshalText(levelVal int) *bytes.Buffer {
 				} else {
 					if len(sta.Channel) == 0 {
 						// Write Station name only
-						by.WriteString(fmt.Sprintf("%s|%s||||||\n", net.Code, sta.Code))
+						by.WriteString(fmt.Sprintf("%s|%s|||||||||||||||\n", net.Code, sta.Code))
 					}
 					for c := 0; c < len(sta.Channel); c++ {
 						cha := &sta.Channel[c]


### PR DESCRIPTION
As described in https://github.com/GeoNet/fdsn/issues/233.

Stations service with level=channel, should be 16 columns result, even there's no such channel. This fixes it.

Deployed in dev and ran test `haz` locally, works well.

Checked source code of ShakingLayer, StrongMotion(lasso), www-geonet. All not affected by this bug.
 