### PR TITLE
chore: allows slash at the end of each query method

### DIFF
--- a/cmd/fdsn-ws/routes.go
+++ b/cmd/fdsn-ws/routes.go
@@ -3,10 +3,11 @@ package main
 import (
 	"bytes"
 	"fmt"
-	"github.com/GeoNet/kit/weft"
 	"net/http"
 	"strings"
 	"time"
+
+	"github.com/GeoNet/kit/weft"
 )
 
 var mux *http.ServeMux
@@ -19,7 +20,7 @@ func init() {
 	mux.HandleFunc("/soh", weft.MakeHandler(soh, weft.UseError))
 
 	// fdsn-ws-event
-	mux.HandleFunc("/fdsnws/event/1", weft.MakeHandler(fdsnEventV1Index, weft.TextError))
+	mux.HandleFunc("/fdsnws/event/1/", weft.MakeHandler(fdsnEventV1Index, weft.TextError))
 	mux.HandleFunc("/fdsnws/event/1/query", weft.MakeHandler(fdsnEventV1Handler, fdsnErrorHandler))
 	mux.HandleFunc("/fdsnws/event/1/version", weft.MakeHandler(fdsnEventVersion, weft.TextError))
 	mux.HandleFunc("/fdsnws/event/1/catalogs", weft.MakeHandler(fdsnEventCatalogs, weft.TextError))
@@ -27,13 +28,13 @@ func init() {
 	mux.HandleFunc("/fdsnws/event/1/application.wadl", weft.MakeHandler(fdsnEventWadl, weft.TextError))
 
 	// fdsn-ws-station
-	mux.HandleFunc("/fdsnws/station/1", weft.MakeHandler(fdsnStationV1Index, weft.TextError))
+	mux.HandleFunc("/fdsnws/station/1/", weft.MakeHandler(fdsnStationV1Index, weft.TextError))
 	mux.HandleFunc("/fdsnws/station/1/query", weft.MakeHandler(fdsnStationV1Handler, fdsnErrorHandler))
 	mux.HandleFunc("/fdsnws/station/1/version", weft.MakeHandler(fdsnStationVersion, weft.TextError))
 	mux.HandleFunc("/fdsnws/station/1/application.wadl", weft.MakeHandler(fdsnStationWadl, weft.TextError))
 
 	// This service implements the dataselect spec from http://www.fdsn.org/webservices/FDSN-WS-Specifications-1.1.pdf.
-	mux.HandleFunc("/fdsnws/dataselect/1", weft.MakeHandler(fdsnDataselectV1Index, weft.TextError))
+	mux.HandleFunc("/fdsnws/dataselect/1/", weft.MakeHandler(fdsnDataselectV1Index, weft.TextError))
 	mux.HandleFunc("/fdsnws/dataselect/1/query", weft.MakeDirectHandler(fdsnDataselectV1Handler, fdsnErrorHandler))
 	mux.HandleFunc("/fdsnws/dataselect/1/version", weft.MakeHandler(fdsnDataselectVersion, weft.TextError))
 	mux.HandleFunc("/fdsnws/dataselect/1/application.wadl", weft.MakeHandler(fdsnDataselectWadl, weft.TextError))

--- a/cmd/fdsn-ws/routes_test.go
+++ b/cmd/fdsn-ws/routes_test.go
@@ -2,11 +2,12 @@ package main
 
 import (
 	"fmt"
-	"github.com/GeoNet/fdsn/internal/holdings"
-	wt "github.com/GeoNet/kit/weft/wefttest"
 	"net/http"
 	"testing"
 	"time"
+
+	"github.com/GeoNet/fdsn/internal/holdings"
+	wt "github.com/GeoNet/kit/weft/wefttest"
 )
 
 // setup() adds event 2015p768477 to the DB.
@@ -15,6 +16,7 @@ var routes = wt.Requests{
 
 	// fdsn-ws-event
 	{ID: wt.L(), URL: "/fdsnws/event/1", Content: "text/html"},
+	{ID: wt.L(), URL: "/fdsnws/event/1/", Content: "text/html"},
 	{ID: wt.L(), URL: "/fdsnws/event/1/query?eventid=2015p768477", Content: "application/xml"},
 	{ID: wt.L(), URL: "/fdsnws/event/1/version", Content: "text/plain"},
 	{ID: wt.L(), URL: "/fdsnws/event/1/catalogs", Content: "application/xml"},
@@ -23,6 +25,7 @@ var routes = wt.Requests{
 
 	// fdsn-ws-dataselect
 	{ID: wt.L(), URL: "/fdsnws/dataselect/1", Content: "text/html"},
+	{ID: wt.L(), URL: "/fdsnws/dataselect/1/", Content: "text/html"},
 	{ID: wt.L(), URL: "/fdsnws/dataselect/1/version", Content: "text/plain"},
 	// an invalid network or no files matching query should give 404 (could also give 204 as per spec)
 	{ID: wt.L(), URL: "/fdsnws/dataselect/1/query?starttime=2016-01-09T00:00:00&endtime=2016-01-09T23:00:00&network=INVALID_NETWORK&station=CHST&location=01&channel=LOG",
@@ -37,6 +40,7 @@ var routes = wt.Requests{
 
 	// fdsn-ws-station
 	{ID: wt.L(), URL: "/fdsnws/station/1", Content: "text/html"},
+	{ID: wt.L(), URL: "/fdsnws/station/1/", Content: "text/html"},
 	{ID: wt.L(), URL: "/fdsnws/station/1/version", Content: "text/plain"},
 	{ID: wt.L(), URL: "/fdsnws/station/1/application.wadl", Content: "application/xml"},
 	{ID: wt.L(), URL: "/fdsnws/station/1/query", Content: "application/xml"},


### PR DESCRIPTION
As requested in https://github.com/GeoNet/tickets/issues/15492

For reviewer: Golang's `mux` auto adds `/path` when the handler pattern is `/path/`. (This means specifying `/path/` makes both `/path` and `/path/` work)
