### PR TITLE
fix: incorrect checking for IU/SNZO

### DIFF
--- a/cmd/fdsn-ws/fdsn_dataselect.go
+++ b/cmd/fdsn-ws/fdsn_dataselect.go
@@ -188,7 +188,9 @@ func fdsnDataselectV1Handler(r *http.Request, w http.ResponseWriter) (int64, err
 		}
 		// We reject all queries for network not "NZ", except special case IU/SNZO.
 		// Note: IU/SNZO won't matched by wildcard queries.
-		if d.Network != "IU" && d.Station != "SNZO" {
+		if d.Network == "^IU$" && d.Station == "^SNZO$" {
+			// let it pass
+		} else {
 			if m, err := regexp.MatchString(d.Network, "NZ"); err != nil || !m {
 				continue
 			}


### PR DESCRIPTION
Regarding https://github.com/GeoNet/tickets/issues/16563.

Previous fix was incorrect due to the pattern string has already changed to regex first so should use regex as comparison. The logic remains the same (only allows IU/SNZO to pass)