### PR TITLE
update event types

### DIFF
--- a/cmd/fdsn-ws/fdsn_event_test.go
+++ b/cmd/fdsn-ws/fdsn_event_test.go
@@ -349,7 +349,7 @@ func TestLongitudeWrap180(t *testing.T) {
 	setup(t)
 	defer teardown()
 
-	// test data: one at 176.3257242 and another at -176.3257242
+	// test data at: 176.3257242, -176.3257242, 179.3257242
 	v := url.Values{}
 	v.Set("minlon", "177.0")
 	e, err := parseEventV1(v)
@@ -362,8 +362,8 @@ func TestLongitudeWrap180(t *testing.T) {
 		t.Error(err)
 	}
 
-	if c != 1 {
-		t.Errorf("expected 1 records got %d\n", c)
+	if c != 2 {
+		t.Errorf("expected 2 records got %d\n", c)
 	}
 
 	v = url.Values{}
@@ -379,8 +379,8 @@ func TestLongitudeWrap180(t *testing.T) {
 		t.Error(err)
 	}
 
-	if c != 2 {
-		t.Errorf("expected 2 records got %d\n", c)
+	if c != 3 {
+		t.Errorf("expected 3 records got %d\n", c)
 	}
 
 	v = url.Values{}
@@ -395,8 +395,8 @@ func TestLongitudeWrap180(t *testing.T) {
 		t.Error(err)
 	}
 
-	if c != 1 {
-		t.Errorf("expected 1 records got %d\n", c)
+	if c != 2 {
+		t.Errorf("expected 2 records got %d\n", c)
 	}
 
 	v = url.Values{}

--- a/cmd/fdsn-ws/fdsn_event_test.go
+++ b/cmd/fdsn-ws/fdsn_event_test.go
@@ -432,6 +432,17 @@ func TestEventTypes(t *testing.T) {
 		{"experimental explosion", false, []interface{}{"experimental explosion"}},
 		{"e*,a*", false, []interface{}{"earthquake", "explosion", "anthropogenic event", "accidental explosion", "experimental explosion", "atmospheric event", "acoustic noise", "avalanche", "artillery strike", "atmospheric meteor explosion"}},
 		{"unknown", false, []interface{}{""}}, // specify "unknown" means query for empty value
+		//new event types
+		{"volcanic long-period", false, []interface{}{"volcanic long-period"}},
+		{"volcanic very-long-period", false, []interface{}{"volcanic very-long-period"}},
+		{"volcanic hybrid", false, []interface{}{"volcanic hybrid"}},
+		{"volcanic tremor", false, []interface{}{"volcanic tremor"}},
+		{"tremor pulse", false, []interface{}{"tremor pulse"}},
+		{"volcano-tectonic", false, []interface{}{"volcano-tectonic"}},
+		{"volcanic rockfall", false, []interface{}{"volcanic rockfall"}},
+		{"pyroclastic flow", false, []interface{}{"pyroclastic flow"}},
+		{"volcanic eruption", false, []interface{}{"volcanic eruption"}},
+		{"lahar", false, []interface{}{"lahar"}},
 	}
 	for _, c := range queryCases {
 		v := url.Values{}

--- a/cmd/fdsn-ws/routes_test.go
+++ b/cmd/fdsn-ws/routes_test.go
@@ -22,6 +22,10 @@ var routes = wt.Requests{
 	{ID: wt.L(), URL: "/fdsnws/event/1/catalogs", Content: "application/xml"},
 	{ID: wt.L(), URL: "/fdsnws/event/1/contributors", Content: "application/xml"},
 	{ID: wt.L(), URL: "/fdsnws/event/1/application.wadl", Content: "application/xml"},
+	//event type
+	{ID: wt.L(), URL: "/fdsnws/event/1/query?starttime=2015-01-01T00:00:00&endtime=2015-12-28T22:00:00&format=text&eventtype=volcanic%20long-period", Content: "text/plain"},
+	{ID: wt.L(), URL: "/fdsnws/event/1/query?starttime=2015-01-01T00:00:00&endtime=2015-12-28T22:00:00&format=text&eventtype=volcanic%20very-long-period", Content: "text/plain"},
+	{ID: wt.L(), URL: "/fdsnws/event/1/query?starttime=2015-01-01T00:00:00&endtime=2015-12-28T22:00:00&format=text&eventtype=other%20event", Content: "text/plain"},
 
 	// fdsn-ws-dataselect
 	{ID: wt.L(), URL: "/fdsnws/dataselect/1", Content: "text/html"},

--- a/cmd/fdsn-ws/server_test.go
+++ b/cmd/fdsn-ws/server_test.go
@@ -40,7 +40,7 @@ func setup(t *testing.T) {
 		t.Fatal("ERROR: problem pinging DB")
 	}
 
-	_, err = db.Exec(`DELETE FROM fdsn.event WHERE publicid = '2015p768477' or publicid = '2015p768478'`)
+	_, err = db.Exec(`DELETE FROM fdsn.event WHERE publicid = '2015p768477' or publicid = '2015p768478' or publicid = '2015p768479'`)
 	if err != nil {
 		t.Log(err)
 	}
@@ -51,7 +51,7 @@ func setup(t *testing.T) {
 	 usedphasecount, usedstationcount, originerror, azimuthalgap, minimumdistance,
 	 magnitudeuncertainty, magnitudestationcount, quakeml12event, sc3ml)
 	 VALUES ('2015p768477', timestamptz '2015-10-12 08:05:01.717692+00', timestamptz '2015-10-12 08:05:01.717692+00',
-	 -40.57806609, 176.3257242, 23.28125, 2.3, 'magnitudetype', false, 'eventtype',
+	 -40.57806609, 176.3257242, 23.28125, 2.3, 'magnitudetype', false, 'volcanic long-period',
 	 'depthtype', 'evaluationmethod', 'earthmodel', 'evaluationmode', 'evaluationstatus',
 	 0, 0, 0, 0, 0,
 	 0, 0, 'quakeml12event', 'sc3ml')`)
@@ -65,10 +65,24 @@ func setup(t *testing.T) {
 	 usedphasecount, usedstationcount, originerror, azimuthalgap, minimumdistance,
 	 magnitudeuncertainty, magnitudestationcount, quakeml12event, sc3ml)
 	 VALUES ('2015p768478', timestamptz '2015-10-12 08:05:02.717692+00', timestamptz '2015-10-12 08:05:02.717692+00',
-	 -40.57806609, -176.3257242, 23.28125, 2.3, 'magnitudetype', false, 'eventtype',
+	 -40.57806609, -176.3257242, 23.28125, 2.3, 'magnitudetype', false, 'volcanic very-long-period',
 	 'depthtype', 'evaluationmethod', 'earthmodel', 'evaluationmode', 'evaluationstatus',
 	 0, 0, 0, 0, 0,
 	 0, 0, 'quakeml12event', 'sc3ml')`)
+	if err != nil {
+		t.Log(err)
+	}
+
+	_, err = db.Exec(`INSERT INTO fdsn.event (publicid, modificationtime, origintime,
+	latitude, longitude, depth, magnitude, magnitudetype, deleted, eventtype,
+	depthtype, evaluationmethod, earthmodel, evaluationmode, evaluationstatus,
+	usedphasecount, usedstationcount, originerror, azimuthalgap, minimumdistance,
+	magnitudeuncertainty, magnitudestationcount, quakeml12event, sc3ml)
+	VALUES ('2015p768479', timestamptz '2015-10-12 09:05:02.717692+00', timestamptz '2015-10-12 09:05:02.717692+00',
+	-23.57806609, 179.3257242, 33.28125, 2.3, 'magnitudetype', false, 'other event',
+	'depthtype', 'evaluationmethod', 'earthmodel', 'evaluationmode', 'evaluationstatus',
+	0, 0, 0, 0, 0,
+	0, 0, 'quakeml12event', 'sc3ml')`)
 	if err != nil {
 		t.Log(err)
 	}

--- a/internal/fdsn/dataselect.go
+++ b/internal/fdsn/dataselect.go
@@ -33,9 +33,9 @@ var dataSelectNotSupported = map[string]bool{
 	"minuimumlength": true,
 }
 
-// nslcReg: FDSN spec allows all ascii, but we'll only allow alpha, number, _, ?, *, "," and "--" (exactly 2 hyphens only)
-var nslcReg = regexp.MustCompile(`^([\w*?,]+|--)$`)
-var eventTypeReg = regexp.MustCompile(`^([\w*?, ]+|--)$`) // space allowed
+// nslcReg: FDSN spec allows all ascii, but we'll only allow alpha, number, _,-, ?, *, "," and "--" (exactly 2 hyphens only)
+var nslcReg = regexp.MustCompile(`^([\w*?,]+(?:-[\w*?,]+)*|--)$`)          // space not allowed
+var eventTypeReg = regexp.MustCompile(`^([\w*?, ]+(?:[ -][\w*?,]+)*|--)$`) // space allowed
 
 // nslcRegPassPattern: This is beyond FDSN spec.
 // Any NSLC regex string doesn't match this pattern we knew it won't generate any results.
@@ -306,6 +306,7 @@ func GenRegex(input []string, emptyDash bool, allowSpace bool) ([]string, error)
 		} else {
 			matched = nslcReg.MatchString(s)
 		}
+
 		if !matched {
 			return nil, fmt.Errorf("invalid parameter:'%s'", s)
 		}


### PR DESCRIPTION
Ticket https://github.com/GeoNet/tickets/issues/17374


Update event type in validation and add tests for new event types

Deployed on dev, try

```
curl -X GET -I "http://tf-dev-fdsn-web-1308277073.ap-southeast-2.elb.amazonaws.com/fdsnws/event/1/query?starttime=2022-01-01T00:00:00&endtime=2025-04-28T22:00:00&format=text&eventtype=volcano-tectonic"
```